### PR TITLE
Update Verus version (has_type for recursive spec functions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You will probably see a lot of information about which functions are taking a lo
 but you can ignore this unless you see an actual error.
 At the end you should see something like "743 verified, 0 errors" (or some other large number).
 
-Last tested with Verus d02a82a5de93c8b064aaf5a43e48360615e9627e
+Last tested with Verus 99fa4d7e9a0c56698fca34de116ca79066c054bf
 
 ### Benchmarking
 

--- a/verus-mimalloc/bin_sizes.rs
+++ b/verus-mimalloc/bin_sizes.rs
@@ -525,6 +525,7 @@ proof fn pow2_adds(e1:nat, e2:nat)
     decreases e1,        
 {
     if e1 == 0 {
+        assert(pow2(e1 as int) == 1);
     } else {
         calc! { (==)
             pow2(e1 as int) * pow2(e2 as int); {}


### PR DESCRIPTION
This seems to be a quirk with Z3's nonlinear arithmetic, where adding an axiom ( https://github.com/verus-lang/verus/commit/99fa4d7e9a0c56698fca34de116ca79066c054bf ) somehow made a proof involving `*` fail.  I tried an equivalent proof that used `+` instead of `*`, and the new axiom did not make the proof about `+` fail like it made the proof about `*` fail.