### PR TITLE
Adapt to finite Set by using ISet instead

### DIFF
--- a/verus-mimalloc/alloc_generic.rs
+++ b/verus-mimalloc/alloc_generic.rs
@@ -299,8 +299,8 @@ fn page_free_list_extend(
     );
     let tracked block_tokens = block_tokens.into_map();
     proof { local.thread_token = _thread_token; local.checked_token = _checked_token; }
-    let tracked mut block_tokens = Map::tracked_map_keys(block_tokens,
-        Map::<int, BlockId>::new(
+    let tracked mut block_tokens = IMap::tracked_map_keys(block_tokens,
+        IMap::<int, BlockId>::new(
           |i: int| cap_nat <= i < cap_nat + extend_nat,
           |i: int| BlockId {
               page_id: page_ptr.page_id@,

--- a/verus-mimalloc/arena.rs
+++ b/verus-mimalloc/arena.rs
@@ -116,7 +116,7 @@ impl Arena {
     */
 }
 
-proof fn points_to_raw_map_to_singleton(tracked m: Map<int, PointsToRaw>, start: int, block_size: int, block_idx_start: int, block_idx_end: int) -> (tracked res: PointsToRaw)
+proof fn points_to_raw_map_to_singleton(tracked m: IMap<int, PointsToRaw>, start: int, block_size: int, block_idx_start: int, block_idx_end: int) -> (tracked res: PointsToRaw)
     requires
         forall |i: int| block_idx_start <= i < block_idx_end ==> m.dom().contains(i),
         forall |i: int| block_idx_start <= i < block_idx_end ==> m.index(i)@.size == block_size,
@@ -133,7 +133,7 @@ proof fn points_to_raw_map_to_singleton(tracked m: Map<int, PointsToRaw>, start:
 
 // TODO this would make a good fn for vstd?
 /*
-proof fn points_to_raw_map_to_singleton(tracked m: Map<int, PointsToRaw>, start: int, block_size: int, n_blocks: int) -> (res: PointsToRaw)
+proof fn points_to_raw_map_to_singleton(tracked m: IMap<int, PointsToRaw>, start: int, block_size: int, n_blocks: int) -> (res: PointsToRaw)
     requires
         forall |i: int| 0 <= i < n_blocks ==> m.dom().contains(i),
         forall |i: int| 0 <= i < n_blocks ==> m.index(i)@.size == block_size,

--- a/verus-mimalloc/bitmap.rs
+++ b/verus-mimalloc/bitmap.rs
@@ -22,7 +22,7 @@ pub open spec fn entry_inv(k: K, user_idx: int, g: G) -> bool {
       && g.has_pointsto_for_all_read_write()
 }
 
-pub open spec fn map_has_range(m: Map<int, G>, start: int, end: int, k: K) -> bool {
+pub open spec fn map_has_range(m: IMap<int, G>, start: int, end: int, k: K) -> bool {
     (forall |i| start <= i < end ==> m.dom().contains(i))
     && (forall |i| start <= i < end ==> entry_inv(k, i, #[trigger] m.index(i)))
 }
@@ -34,7 +34,7 @@ pub open spec fn map_has_range(m: Map<int, G>, start: int, end: int, k: K) -> bo
 
 struct_with_invariants!{
     pub struct Bitmap {
-        data: Vec<AtomicUsize<_, Map<int, G>, _>>,
+        data: Vec<AtomicUsize<_, IMap<int, G>, _>>,
         ghost k: K,
     }
 
@@ -49,7 +49,7 @@ struct_with_invariants!{
             forall |field_idx: int|
             where (0 <= field_idx < self.data@.len())
             specifically (self.data@.index(field_idx))
-            is (v: usize, gmap: Map<int, G>)
+            is (v: usize, gmap: IMap<int, G>)
         {
             forall |bitidx: int| 
                 ! #[trigger] has_bit(v, bitidx)
@@ -75,7 +75,7 @@ impl Bitmap {
     }
 
     pub fn bitmap_try_find_from_claim_across(&self, start_field_idx: usize, count: usize)
-        -> (res: (bool, usize, Tracked<Map<int, G>>))
+        -> (res: (bool, usize, Tracked<IMap<int, G>>))
     requires
         self.wf(),
         0 <= start_field_idx < self.len(),
@@ -94,7 +94,7 @@ impl Bitmap {
     }
 
     fn bitmap_try_find_from_claim(&self, start_field_idx: usize, count: usize)
-        -> (res: (bool, usize, Tracked<Map<int, G>>))
+        -> (res: (bool, usize, Tracked<IMap<int, G>>))
     requires
         self.wf(),
         0 <= start_field_idx < self.data@.len(),
@@ -131,11 +131,11 @@ impl Bitmap {
             idx = idx + 1;
         }
 
-        return (false, 0, Tracked(Map::tracked_empty()));
+        return (false, 0, Tracked(IMap::tracked_empty()));
     }
 
     fn bitmap_try_find_claim_field(&self, field_idx: usize, count: usize)
-        -> (res: (bool, usize, Tracked<Map<int, G>>))
+        -> (res: (bool, usize, Tracked<IMap<int, G>>))
     requires
         self.wf(),
         0 <= field_idx < self.data@.len(),
@@ -153,7 +153,7 @@ impl Bitmap {
 
         let mut map = atomic.load();
         if map == !(0usize) {
-            return (false, 0, Tracked(Map::tracked_empty()));
+            return (false, 0, Tracked(IMap::tracked_empty()));
         }
 
         assert((1usize << count) >= 1usize) by(bit_vector)
@@ -177,8 +177,8 @@ impl Bitmap {
         {
             let mapm = map & m;
             if mapm == 0 {
-                let tracked mut res_map: Map<int, G>;
-                proof { res_map = Map::tracked_empty(); }
+                let tracked mut res_map: IMap<int, G>;
+                proof { res_map = IMap::tracked_empty(); }
 
                 let newmap = map | m;
                 let res = my_atomic_with_ghost!(
@@ -188,7 +188,7 @@ impl Bitmap {
                     ghost gmap =>
                 {
                     if res.is_Ok() {
-                        let range = set_int_range(
+                        let range = ISet::<int>::range(
                             usize::BITS * field_idx + bitidx,
                             usize::BITS * field_idx + bitidx + count);
 
@@ -301,7 +301,7 @@ impl Bitmap {
             }
         }
 
-        return (false, 0, Tracked(Map::tracked_empty()));
+        return (false, 0, Tracked(IMap::tracked_empty()));
     }
         
 

--- a/verus-mimalloc/commit_mask.rs
+++ b/verus-mimalloc/commit_mask.rs
@@ -3,11 +3,10 @@ use crate::config::*;
 use crate::tokens::*;
 use crate::layout::*;
 use crate::types::*;
-use vstd::set_lib::set_int_range;
 
 verus!{
 
-proof fn lemma_map_distribute<S,T>(s1: Set<S>, s2: Set<S>, f: spec_fn(S) -> T)
+proof fn lemma_map_distribute<S,T>(s1: ISet<S>, s2: ISet<S>, f: spec_fn(S) -> T)
     ensures s1.union(s2).map(f) == s1.map(f).union(s2.map(f))
 {
     assert forall|x:T| #![auto] s1.map(f).union(s2.map(f)).contains(x) implies s1.union(s2).map(f).contains(x) by {
@@ -21,9 +20,9 @@ proof fn lemma_map_distribute<S,T>(s1: Set<S>, s2: Set<S>, f: spec_fn(S) -> T)
 }
 
 proof fn lemma_map_distribute_auto<S,T>()
-    ensures forall|s1: Set<S>, s2: Set<S>, f: spec_fn(S) -> T| s1.union(s2).map(f) == #[trigger] s1.map(f).union(s2.map(f))
+    ensures forall|s1: ISet<S>, s2: ISet<S>, f: spec_fn(S) -> T| s1.union(s2).map(f) == #[trigger] s1.map(f).union(s2.map(f))
 {
-    assert forall|s1: Set<S>, s2: Set<S>, f: spec_fn(S) -> T| s1.union(s2).map(f) == #[trigger] s1.map(f).union(s2.map(f)) by {
+    assert forall|s1: ISet<S>, s2: ISet<S>, f: spec_fn(S) -> T| s1.union(s2).map(f) == #[trigger] s1.map(f).union(s2.map(f)) by {
         lemma_map_distribute(s1, s2, f);
     }
 }
@@ -194,8 +193,8 @@ pub struct CommitMask {
 }
 
 impl CommitMask {
-    pub closed spec fn view(&self) -> Set<int> {
-        Set::new(|t: (int, usize)|
+    pub closed spec fn view(&self) -> ISet<int> {
+        ISet::new(|t: (int, usize)|
                  0 <= t.0 < 8 && t.1 < 64
                  && is_bit_set(self.mask[t.0], t.1)
         ).map(|t: (int, usize)| t.0 * 64 + t.1)
@@ -217,7 +216,7 @@ impl CommitMask {
         assert forall|a: int, b: usize| 0 <= a < 8 && b < 64 && is_bit_set(self.mask[a], b)
             implies self@.contains(a * 64 + b)
         by {
-            assert(Set::new(|t: (int, usize)|
+            assert(ISet::new(|t: (int, usize)|
                      0 <= t.0 < 8 && t.1 < 64
                      && is_bit_set(self.mask[t.0], t.1)
             ).contains((a, b))) by (nonlinear_arith)
@@ -226,8 +225,8 @@ impl CommitMask {
     }
 
     #[verifier::opaque]
-    pub open spec fn bytes(&self, segment_id: SegmentId) -> Set<int> {
-        Set::<int>::new(|addr: int|
+    pub open spec fn bytes(&self, segment_id: SegmentId) -> ISet<int> {
+        ISet::<int>::new(|addr: int|
             self@.contains(
                 (addr - segment_start(segment_id)) / COMMIT_SIZE as int
             )
@@ -235,13 +234,13 @@ impl CommitMask {
     }
 
     pub fn empty() -> (cm: CommitMask)
-        ensures cm@ == Set::<int>::empty()
+        ensures cm@ == ISet::<int>::empty()
     {
         let res = CommitMask { mask: [ 0, 0, 0, 0, 0, 0, 0, 0 ] };
         proof {
             lemma_is_bit_set();
             res.lemma_view();
-            assert(res@ =~= Set::<int>::empty());
+            assert(res@ =~= ISet::<int>::empty());
         }
         res
     }
@@ -372,19 +371,19 @@ impl CommitMask {
             forall|j: int| 0 <= j < i ==> other.mask[j] == self.mask[j],
             forall|j: int| i < j < 8 ==> other.mask[j] == self.mask[j],
         ensures
-            other@ == self@.union(Set::new(|b: usize| b < 64 && is_bit_set(other.mask[i], b)).map(|b: usize| 64 * i + b)),
+            other@ == self@.union(ISet::new(|b: usize| b < 64 && is_bit_set(other.mask[i], b)).map(|b: usize| 64 * i + b)),
     {
-        let s_un = Set::new(|b: usize| b < 64 && is_bit_set(other.mask[i], b));
+        let s_un = ISet::new(|b: usize| b < 64 && is_bit_set(other.mask[i], b));
         let f_un = |b: usize| 64 * i + b;
         let f = |t: (int, usize)| t.0 * 64 + t.1;
-        let s_full = Set::new(|t: (int, usize)| 0 <= t.0 < 8 && t.1 < 64 && is_bit_set(self.mask[t.0], t.1));
-        let s_full_o = Set::new(|t: (int, usize)| 0 <= t.0 < 8 && t.1 < 64 && is_bit_set(other.mask[t.0], t.1));
-        let s1 = Set::new(|t: (int, usize)| 0 <= t.0 < i && t.1 < 64 && is_bit_set(self.mask[t.0], t.1));
-        let s2 = Set::new(|t: (int, usize)| t.0 == i && t.1 < 64 && is_bit_set(self.mask[i], t.1));
-        let s2o = Set::new(|t: (int, usize)| t.0 == i && t.1 < 64 && is_bit_set(other.mask[i], t.1));
-        let s3 = Set::new(|t: (int, usize)| i <  t.0 < 8 && t.1 < 64 && is_bit_set(self.mask[t.0], t.1));
+        let s_full = ISet::new(|t: (int, usize)| 0 <= t.0 < 8 && t.1 < 64 && is_bit_set(self.mask[t.0], t.1));
+        let s_full_o = ISet::new(|t: (int, usize)| 0 <= t.0 < 8 && t.1 < 64 && is_bit_set(other.mask[t.0], t.1));
+        let s1 = ISet::new(|t: (int, usize)| 0 <= t.0 < i && t.1 < 64 && is_bit_set(self.mask[t.0], t.1));
+        let s2 = ISet::new(|t: (int, usize)| t.0 == i && t.1 < 64 && is_bit_set(self.mask[i], t.1));
+        let s2o = ISet::new(|t: (int, usize)| t.0 == i && t.1 < 64 && is_bit_set(other.mask[i], t.1));
+        let s3 = ISet::new(|t: (int, usize)| i <  t.0 < 8 && t.1 < 64 && is_bit_set(self.mask[t.0], t.1));
         assert(s_full =~= s1.union(s2).union(s3));
-        assert(s2 =~= Set::empty()) by { lemma_is_bit_set(); }
+        assert(s2 =~= ISet::empty()) by { lemma_is_bit_set(); }
         lemma_map_distribute_auto::<(int,usize),int>();
         assert(s_full.map(f) =~= s1.map(f).union(s2.map(f)).union(s3.map(f)));
         assert(s_full_o =~= s_full.union(s2o));
@@ -393,7 +392,7 @@ impl CommitMask {
         };
         assert forall|x| #![auto] s2o.map(f).contains(x) implies s_un.map(f_un).contains(x) by {
             let y = choose|y| s2o.contains(y) && f(y) == x;
-            assert(Set::new(|b: usize| b < 64 && is_bit_set(other.mask[i], b)).contains(y.1));
+            assert(ISet::new(|b: usize| b < 64 && is_bit_set(other.mask[i], b)).contains(y.1));
         };
         assert(s_un.map(f_un) =~= s2o.map(f));
     }
@@ -401,8 +400,8 @@ impl CommitMask {
     pub fn create(&mut self, idx: usize, count: usize)
         requires
             idx + count <= COMMIT_MASK_BITS,
-            old(self)@ == Set::<int>::empty(),
-        ensures self@ == Set::new(|i: int| idx <= i < idx + count),
+            old(self)@ == ISet::<int>::empty(),
+        ensures self@ == ISet::new(|i: int| idx <= i < idx + count),
     {
         proof {
             const_facts();
@@ -418,15 +417,15 @@ impl CommitMask {
         if count == COMMIT_MASK_BITS as usize {
             self.create_full();
         } else if count == 0 {
-            assert(self@ =~= Set::new(|i: int| idx <= i < idx + count));
+            assert(self@ =~= ISet::new(|i: int| idx <= i < idx + count));
         } else {
             let mut i = idx / usize::BITS as usize;
             let mut ofs: usize = idx % usize::BITS as usize;
             let mut bitcount = count;
-            assert(Set::new(|j: int| idx <= j < idx + (count - bitcount)) =~= Set::empty());
+            assert(ISet::new(|j: int| idx <= j < idx + (count - bitcount)) =~= ISet::empty());
             while bitcount > 0
                 invariant
-                    self@ == Set::new(|j: int| idx <= j < idx + (count - bitcount)),
+                    self@ == ISet::new(|j: int| idx <= j < idx + (count - bitcount)),
                     ofs == if count == bitcount { idx % 64 } else { 0 },
                     bitcount > 0 ==> 64 * i + ofs == idx + (count - bitcount),
                     idx + count <= 512,
@@ -460,86 +459,86 @@ impl CommitMask {
                     let oofs = oofs@;
                     lemma_is_bit_set();
                     old_self@.lemma_change_one_entry(self, oi as int);
-                    assert(self@ == old_self@@.union(Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b)));
+                    assert(self@ == old_self@@.union(ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b)));
                     // TODO: a lot of duplicated proof structure here, should be able to
                     // somehow lift that structure out of the if-else
                     if oofs > 0 { // first iteration
-                        assert(Set::new(|j: int| idx <= j < idx + (count - bitcount))
-                               =~= Set::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount)));
+                        assert(ISet::new(|j: int| idx <= j < idx + (count - bitcount))
+                               =~= ISet::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount)));
                         if obc < 64 {
                             assert(mask == sub(1usize << c, 1usize) << oofs);
                             lemma_bitmask_to_is_bit_set(c, oofs);
-                            assert(Set::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount))
-                                   =~= Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b))
+                            assert(ISet::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount))
+                                   =~= ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b))
                             by {
-                                let s1 = Set::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount));
-                                let s2 = Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b);
+                                let s1 = ISet::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount));
+                                let s2 = ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b);
                                 assert(forall|j: usize| idx + (count - obc) <= j < idx + (count - bitcount) ==> #[trigger] is_bit_set(self.mask[oi as int], mod64(j)));
                                 assert forall|x: int| s1.contains(x) implies s2.contains(x) by {
                                     let b = x % 64;
-                                    assert(Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).contains((x % 64) as usize));
+                                    assert(ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).contains((x % 64) as usize));
                                 }
                             }
-                            assert(Set::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount))
-                                   =~= Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b));
+                            assert(ISet::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount))
+                                   =~= ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b));
                         } else {
                             assert(mask == sub(1usize << sub(64usize, oofs), 1usize) << oofs);
                             lemma_bitmask_to_is_bit_set(sub(64, oofs), oofs);
-                            assert(Set::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount))
-                                   =~= Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b))
+                            assert(ISet::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount))
+                                   =~= ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b))
                             by {
-                                let s1 = Set::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount));
-                                let s2 = Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b);
+                                let s1 = ISet::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount));
+                                let s2 = ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b);
                                 assert forall|x: int| s1.contains(x) implies s2.contains(x) by { // unstable
-                                    assert(Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).contains((x % 64) as usize));
+                                    assert(ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).contains((x % 64) as usize));
                                 }
                             }
-                            assert(Set::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount))
-                                   =~= Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b));
+                            assert(ISet::new(|j: int| idx + (count - obc) <= j < idx + (count - bitcount))
+                                   =~= ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b));
                         }
                     } else if obc < 64 { // last iteration
-                        assert(Set::new(|j: int| idx <= j < idx + (count - bitcount))
-                               =~= Set::new(|j: int| idx <= j < idx + (count - obc))
-                                   .union(Set::new(|j: int| idx + (count - obc) <= j < idx + count)));
+                        assert(ISet::new(|j: int| idx <= j < idx + (count - bitcount))
+                               =~= ISet::new(|j: int| idx <= j < idx + (count - obc))
+                                   .union(ISet::new(|j: int| idx + (count - obc) <= j < idx + count)));
                         assert(mask == (1usize << obc) - 1usize);
                         lemma_bitmask_to_is_bit_set(obc, 0);
-                        assert(Set::new(|j: int| idx + (count - obc) <= j < idx + count)
-                               =~= Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b))
+                        assert(ISet::new(|j: int| idx + (count - obc) <= j < idx + count)
+                               =~= ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b))
                         by {
-                            let s1 = Set::new(|j: int| idx + (count - obc) <= j < idx + count);
-                            let s2 = Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b);
+                            let s1 = ISet::new(|j: int| idx + (count - obc) <= j < idx + count);
+                            let s2 = ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b);
                             assert forall|x: int| s1.contains(x) implies s2.contains(x) by {
-                                assert(Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).contains((x % 64) as usize));
+                                assert(ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).contains((x % 64) as usize));
                             }
                         }
-                        assert(Set::new(|j: int| idx + (count - obc) <= j < idx + count)
-                               =~= Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b));
+                        assert(ISet::new(|j: int| idx + (count - obc) <= j < idx + count)
+                               =~= ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b));
                     } else {
-                        assert(Set::new(|j: int| idx <= j < idx + (count - bitcount))
-                               =~= Set::new(|j: int| idx <= j < idx + (count - obc))
-                                   .union(Set::new(|j: int| idx + (count - obc) <= j < idx + (count - obc) + 64)));
+                        assert(ISet::new(|j: int| idx <= j < idx + (count - bitcount))
+                               =~= ISet::new(|j: int| idx <= j < idx + (count - obc))
+                                   .union(ISet::new(|j: int| idx + (count - obc) <= j < idx + (count - obc) + 64)));
                         assert(mask == !0usize);
-                        let new = Set::new(|j: int| idx + (count - obc) <= j < idx + (count - obc) + 64);
-                        assert(Set::new(|j: int| 64 * oi <= j < 64 * oi + 64)
-                               =~= Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b))
+                        let new = ISet::new(|j: int| idx + (count - obc) <= j < idx + (count - obc) + 64);
+                        assert(ISet::new(|j: int| 64 * oi <= j < 64 * oi + 64)
+                               =~= ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b))
                         by {
-                            let s1 = Set::new(|j: int| 64 * oi <= j < 64 * oi + 64);
-                            let s2 = Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b);
+                            let s1 = ISet::new(|j: int| 64 * oi <= j < 64 * oi + 64);
+                            let s2 = ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b);
                             assert forall|x: int| s1.contains(x) implies s2.contains(x) by {
-                                assert(Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).contains((x % 64) as usize));
+                                assert(ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).contains((x % 64) as usize));
                             }
                         }
-                        assert(Set::new(|j: int| 64 * oi <= j < 64 * oi + 64)
-                               =~= Set::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b));
+                        assert(ISet::new(|j: int| 64 * oi <= j < 64 * oi + 64)
+                               =~= ISet::new(|b: usize| b < 64 && is_bit_set(self.mask[oi as int], b)).map(|b: usize| 64 * oi + b));
                     }
                 }
-                assert(self@ =~= Set::new(|j: int| idx <= j < idx + (count - bitcount)));
+                assert(self@ =~= ISet::new(|j: int| idx <= j < idx + (count - bitcount)));
             }
         }
     }
 
     pub fn create_empty(&mut self)
-        ensures self@ == Set::<int>::empty(),
+        ensures self@ == ISet::<int>::empty(),
     {
         let mut i = 0;
         while i < 8
@@ -551,12 +550,12 @@ impl CommitMask {
         proof {
             lemma_is_bit_set();
             self.lemma_view();
-            assert(self@ =~= Set::<int>::empty());
+            assert(self@ =~= ISet::<int>::empty());
         }
     }
 
     pub fn create_full(&mut self)
-        ensures self@ == Set::new(|i: int| 0 <= i < COMMIT_MASK_BITS),
+        ensures self@ == ISet::new(|i: int| 0 <= i < COMMIT_MASK_BITS),
     {
         let mut i = 0;
         while i < 8
@@ -569,14 +568,14 @@ impl CommitMask {
             const_facts();
             lemma_is_bit_set();
             self.lemma_view();
-            let seq_set = Set::new(|i: int| 0 <= i < COMMIT_MASK_BITS);
-            let bit_set = Set::new(|t: (int, int)| 0 <= t.0 < 8 && 0 <= t.1 < 64)
+            let seq_set = ISet::new(|i: int| 0 <= i < COMMIT_MASK_BITS);
+            let bit_set = ISet::new(|t: (int, int)| 0 <= t.0 < 8 && 0 <= t.1 < 64)
                    .map(|t: (int, int)| t.0 * 64 + t.1);
             assert forall|i: int| seq_set.contains(i) implies bit_set.contains(i) by {
-                assert(Set::new(|t: (int, int)| 0 <= t.0 < 8 && 0 <= t.1 < 64).contains((i / 64, i % 64)));
+                assert(ISet::new(|t: (int, int)| 0 <= t.0 < 8 && 0 <= t.1 < 64).contains((i / 64, i % 64)));
             }
             assert(seq_set =~= bit_set);
-            assert(self@ =~= Set::new(|i: int| 0 <= i < COMMIT_MASK_BITS));
+            assert(self@ =~= ISet::new(|i: int| 0 <= i < COMMIT_MASK_BITS));
         }
     }
 
@@ -709,7 +708,7 @@ impl CommitMask {
     }
 
     pub fn is_empty(&self) -> (b: bool)
-    ensures b == (self@ == Set::<int>::empty())
+    ensures b == (self@ == ISet::<int>::empty())
     {
         let mut i = 0;
         while i < 8
@@ -729,13 +728,13 @@ impl CommitMask {
         proof {
             lemma_is_bit_set();
             self.lemma_view();
-            assert(self@ =~= Set::<int>::empty());
+            assert(self@ =~= ISet::<int>::empty());
         }
         return true;
     }
 
     pub fn is_full(&self) -> (b: bool)
-    ensures b == (self@ == Set::new(|i: int| 0 <= i < COMMIT_MASK_BITS))
+    ensures b == (self@ == ISet::new(|i: int| 0 <= i < COMMIT_MASK_BITS))
     {
         let mut i = 0;
         while i < 8
@@ -769,7 +768,7 @@ impl CommitMask {
                 assert(0 <= u < 64);
                 assert(self@.contains(t * 64 + u));
             }
-            assert(self@ =~= Set::new(|i: int| 0 <= i < COMMIT_MASK_BITS));
+            assert(self@ =~= ISet::new(|i: int| 0 <= i < COMMIT_MASK_BITS));
         }
         return true;
     }
@@ -777,7 +776,7 @@ impl CommitMask {
 
 pub proof fn set_int_range_commit_size(sid: SegmentId, mask: CommitMask)
     requires mask@.contains(0)
-    ensures set_int_range(segment_start(sid), segment_start(sid) + COMMIT_SIZE) <= mask.bytes(sid)
+    ensures vstd::iset_lib::set_int_range(segment_start(sid), segment_start(sid) + COMMIT_SIZE) <= mask.bytes(sid)
 {
     reveal(CommitMask::bytes);
 }

--- a/verus-mimalloc/commit_segment.rs
+++ b/verus-mimalloc/commit_segment.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
 use vstd::prelude::*;
-use vstd::set_lib::*;
+use vstd::iset_lib::*;
 
 use crate::commit_mask::*;
 use crate::types::*;
@@ -32,17 +32,17 @@ fn segment_commit_mask(
         segment_ptr as int + SEGMENT_SIZE <= usize::MAX,
         p >= segment_ptr as int,
         p + size <= segment_ptr as int + SEGMENT_SIZE,
-        old(cm)@ == Set::<int>::empty(),
+        old(cm)@ == ISet::<int>::empty(),
     ensures ({ let (start_p, full_size) = res; {
-        (cm@ == Set::<int>::empty() ==> !conservative ==> size == 0)
-        && (cm@ != Set::<int>::empty() ==>
+        (cm@ == ISet::<int>::empty() ==> !conservative ==> size == 0)
+        && (cm@ != ISet::<int>::empty() ==>
             (conservative ==> p <= start_p as int <= start_p as int + full_size <= p + size)
             && (!conservative ==> start_p as int <= p <= p + size <= start_p as int + full_size)
             && start_p as int >= segment_ptr as int
             && start_p as int + full_size <= segment_ptr as int + SEGMENT_SIZE
-            //&& (!conservative ==> set_int_range((p - segment_ptr) / COMMIT_SIZE as int,
+            //&& (!conservative ==> ISet::<int>::range((p - segment_ptr) / COMMIT_SIZE as int,
             //    (((p + size - 1 - segment_ptr as int) / COMMIT_SIZE as int) + 1)).subset_of(cm@))
-            //&& (conservative ==> cm@ <= set_int_range((p - segment_ptr) / COMMIT_SIZE as int,
+            //&& (conservative ==> cm@ <= ISet::<int>::range((p - segment_ptr) / COMMIT_SIZE as int,
             //    (((p + size - 1 - segment_ptr as int) / COMMIT_SIZE as int) + 1)))
             && start_p as int % COMMIT_SIZE as int == 0
             && full_size as int % COMMIT_SIZE as int == 0

--- a/verus-mimalloc/commit_segment.rs
+++ b/verus-mimalloc/commit_segment.rs
@@ -245,22 +245,23 @@ fn segment_commitx(
     });
     
     proof {
-        let cm = local.segments[sid].main.value().commit_mask@;
-        let old_cm = old(local).segments[sid].main.value().commit_mask@;
-
         if commit {
-            assert(local.decommit_mask(sid).bytes(sid).subset_of( old(local).decommit_mask(sid).bytes(sid) ) && old(local).commit_mask(sid).bytes(sid).subset_of( local.commit_mask(sid).bytes(sid) )) by { reveal(CommitMask::bytes); }
-            assert((old(local).segments[sid].mem.os_rw_bytes() + (local.commit_mask(sid).bytes(sid) - old(local).commit_mask(sid).bytes(sid))).subset_of(local.segments[sid].mem.os_rw_bytes())) by { reveal(CommitMask::bytes); }
-            preserves_mem_chunk_good_on_commit_with_mask_set(*old(local), *local, sid);
-            assert(local.mem_chunk_good(sid));
-            assert forall |sid1| sid1 != sid && old(local).mem_chunk_good(sid1)
-                implies local.mem_chunk_good(sid1)
-            by {
-                preserves_mem_chunk_good_on_commit(*old(local), *local, sid1);
-            }
-            assert(local.unused_pages === old(local).unused_pages);
-            assert(local.page_organization === old(local).page_organization);
-            assert(local.wf_main());
+            assert(local.wf_main()) by {
+                let cm = local.segments[sid].main.value().commit_mask@;
+                let old_cm = old(local).segments[sid].main.value().commit_mask@;
+
+                assert(local.decommit_mask(sid).bytes(sid).subset_of( old(local).decommit_mask(sid).bytes(sid) ) && old(local).commit_mask(sid).bytes(sid).subset_of( local.commit_mask(sid).bytes(sid) )) by { reveal(CommitMask::bytes); }
+                assert((old(local).segments[sid].mem.os_rw_bytes() + (local.commit_mask(sid).bytes(sid) - old(local).commit_mask(sid).bytes(sid))).subset_of(local.segments[sid].mem.os_rw_bytes())) by { reveal(CommitMask::bytes); }
+                preserves_mem_chunk_good_on_commit_with_mask_set(*old(local), *local, sid);
+                assert(local.mem_chunk_good(sid));
+                assert forall |sid1| sid1 != sid && old(local).mem_chunk_good(sid1)
+                    implies local.mem_chunk_good(sid1)
+                by {
+                    preserves_mem_chunk_good_on_commit(*old(local), *local, sid1);
+                }
+                assert(local.unused_pages === old(local).unused_pages);
+                assert(local.page_organization === old(local).page_organization);
+            };
 
             assert forall |j: int| set_int_range(p as int, p + size).contains(j)
                 implies local.commit_mask(sid).bytes(sid).contains(j)
@@ -272,34 +273,50 @@ fn segment_commitx(
             }
             assert(set_int_range(p as int, p + size) <= local.commit_mask(segment.segment_id@).bytes(segment.segment_id@) - local.decommit_mask(segment.segment_id@).bytes(segment.segment_id@)) by { reveal(CommitMask::bytes); };
         } else {
-            assert forall |sid1| sid1 != sid && old(local).mem_chunk_good(sid1)
-                implies local.mem_chunk_good(sid1)
-            by {
-                preserves_mem_chunk_good_on_commit_with_mask_set(*old(local), *local, sid1);
-            }
+            assert(local.wf_main()) by {
+                assert forall |sid1| sid1 != sid && old(local).mem_chunk_good(sid1)
+                    implies local.mem_chunk_good(sid1)
+                by {
+                    preserves_mem_chunk_good_on_commit_with_mask_set(*old(local), *local, sid1);
+                }
 
-            let local1 = *old(local);
-            let local2 = *local;
-            assert(local2.commit_mask(sid).bytes(sid) =~=
-                local1.commit_mask(sid).bytes(sid) -
-                (local1.decommit_mask(sid).bytes(sid) - local2.decommit_mask(sid).bytes(sid)))
-            by {
-                reveal(CommitMask::bytes);
-            }
-            assert(local2.decommit_mask(sid).bytes(sid) <= local1.decommit_mask(sid).bytes(sid))
-            by {
-                reveal(CommitMask::bytes);
-            }
-            assert((local1.segments[sid].mem.os_rw_bytes() - local2.segments[sid].mem.os_rw_bytes())
-                <= (local1.decommit_mask(sid).bytes(sid) - local2.decommit_mask(sid).bytes(sid)))
-            by {
-                reveal(CommitMask::bytes);
-            }
+                let local1 = *old(local);
+                let local2 = *local;
+                assert(local2.commit_mask(sid).bytes(sid) =~=
+                    local1.commit_mask(sid).bytes(sid) -
+                    (local1.decommit_mask(sid).bytes(sid) - local2.decommit_mask(sid).bytes(sid)))
+                by {
+                    reveal(CommitMask::bytes);
+                }
+                assert(local2.decommit_mask(sid).bytes(sid) <= local1.decommit_mask(sid).bytes(sid))
+                by {
+                    reveal(CommitMask::bytes);
+                }
+                assert((local1.segments[sid].mem.os_rw_bytes() - local2.segments[sid].mem.os_rw_bytes())
+                    <= (local1.decommit_mask(sid).bytes(sid) - local2.decommit_mask(sid).bytes(sid)))
+                by {
+                    reveal(CommitMask::bytes);
+                }
 
-            preserves_mem_chunk_good_on_decommit(*old(local), *local, sid);
-            assert(local.mem_chunk_good(sid));
-            assert(local.unused_pages === old(local).unused_pages);
-            assert(local.page_organization === old(local).page_organization);
+                assert(local2.segments[sid].mem.os_rw_bytes() <= local1.segments[sid].mem.os_rw_bytes());
+                assert(local2.segments[sid].mem.points_to.dom().to_iset() =~=
+                    local1.segments[sid].mem.points_to.dom().to_iset() -
+                    (local1.segments[sid].mem.os_rw_bytes() - local2.segments[sid].mem.os_rw_bytes()))
+                by {
+                    assert_isets_equal!(
+                        local2.segments[sid].mem.points_to.dom().to_iset(),
+                        local1.segments[sid].mem.points_to.dom().to_iset() -
+                            (local1.segments[sid].mem.os_rw_bytes() - local2.segments[sid].mem.os_rw_bytes()),
+                        a => {
+                        }
+                    );
+                };
+
+                preserves_mem_chunk_good_on_decommit(*old(local), *local, sid);
+                assert(local.mem_chunk_good(sid));
+                assert(local.unused_pages === old(local).unused_pages);
+                assert(local.page_organization === old(local).page_organization);
+            };
 
             assert(local.wf_main());
         }

--- a/verus-mimalloc/dealloc_token.rs
+++ b/verus-mimalloc/dealloc_token.rs
@@ -86,7 +86,7 @@ impl MimDeallocInner {
             && md.inst() == self.mim_instance
         })
     {
-        let tracked (x, y) = points_to_raw.split(set_int_range(self.ptr as int, self.ptr as int + sz));
+        let tracked (x, y) = points_to_raw.split(Set::<int>::range(self.ptr as int, self.ptr as int + sz));
         let tracked md = MimDealloc { padding: y, _size: sz, inner: self };
         (md, x)
     }

--- a/verus-mimalloc/free.rs
+++ b/verus-mimalloc/free.rs
@@ -39,10 +39,10 @@ verus!{
 //
 //   If the 'delay' state is in 'UseDelayedFree' (the unusual case):
 //
-//     Set 'delay' to Freeing
+//     ISet 'delay' to Freeing
 //     Follow the heap pointer to access the Heap
 //     Atomically add to the delayed free list.
-//     Set 'delay' to NoDelaying
+//     ISet 'delay' to NoDelaying
 //
 //     (The purpose of setting the 'Freeing' state is to ensure that the Heap remains
 //     valid while we perform this operation.)

--- a/verus-mimalloc/init.rs
+++ b/verus-mimalloc/init.rs
@@ -3,10 +3,10 @@
 use core::intrinsics::{unlikely, likely};
 
 use vstd::prelude::*;
+use vstd::iset_lib::*;
 use vstd::raw_ptr::*;
 use vstd::*;
 use vstd::modes::*;
-use vstd::set_lib::*;
 use vstd::cell::pcell::*;
 use vstd::shared::Shared;
 
@@ -58,13 +58,13 @@ impl RightToUseThread {
 
 //impl Copy for Global { }
 
-pub proof fn global_init() -> (tracked res: (Global, Map<ThreadId, Mim::right_to_use_thread>))    // $line_count$Trusted$
+pub proof fn global_init() -> (tracked res: (Global, IMap<ThreadId, Mim::right_to_use_thread>))    // $line_count$Trusted$
     ensures // $line_count$Trusted$
         forall |tid: ThreadId| #[trigger] res.1.dom().contains(tid) // $line_count$Trusted$
           && res.0.wf_right_to_use_thread(res.1[tid], tid) // $line_count$Trusted$
 {
     let tracked (Tracked(instance), Tracked(right_to_set_inst), _, _, Tracked(rights), _, _, _, _, _, _, _, _) = Mim::Instance::initialize(
-        Map::tracked_empty(), Map::tracked_empty(), Map::tracked_empty(),
+        IMap::tracked_empty(), IMap::tracked_empty(), IMap::tracked_empty(),
         );
     let tracked my_inst = instance.set_inst(instance.id(), right_to_set_inst.tracked_unwrap());
     (Global { instance, my_inst }, rights.into_map())
@@ -205,8 +205,8 @@ pub fn heap_init(Tracked(global): Tracked<Global>, // $line_count$Trusted$
                 heap: HeapState {
                     shared_access: heap_shared_access,
                 },
-                segments: Map::empty(),
-                pages: Map::empty(),
+                segments: IMap::empty(),
+                pages: IMap::empty(),
             },
             &global.my_inst,
             right,
@@ -232,10 +232,10 @@ pub fn heap_init(Tracked(global): Tracked<Global>, // $line_count$Trusted$
         },
         tld_id: tld.tld_id@,
         tld: points_to_tld,
-        segments: Map::tracked_empty(),
-        pages: Map::tracked_empty(),
-        psa: Map::empty(),
-        unused_pages: Map::tracked_empty(),
+        segments: IMap::tracked_empty(),
+        pages: IMap::tracked_empty(),
+        psa: IMap::empty(),
+        unused_pages: IMap::tracked_empty(),
         page_organization,
         page_empty_global: page_empty_ptr_access,
     };
@@ -665,8 +665,8 @@ fn thread_data_alloc()
     }
 
     proof {
-        //assert(set_int_range(addr as int, addr as int + 4096) <= mc.range_os_rw());
-        //assert(set_int_range(addr as int, addr as int + 4096) <= mc.range_points_to());
+        //assert(ISet::<int>::range(addr as int, addr as int + 4096) <= mc.range_os_rw());
+        //assert(ISet::<int>::range(addr as int, addr as int + 4096) <= mc.range_points_to());
         //assert(SIZEOF_HEAP + SIZEOF_TLD < page_size());
         //assert(mc.pointsto_has_range(addr as int, SIZEOF_HEAP + SIZEOF_TLD));
     }

--- a/verus-mimalloc/linked_list.rs
+++ b/verus-mimalloc/linked_list.rs
@@ -5,7 +5,7 @@ use vstd::prelude::*;
 use vstd::raw_ptr::*;
 use vstd::modes::*;
 use vstd::*;
-use vstd::set_lib::*;
+use vstd::iset_lib::*;
 use vstd::layout::*;
 use vstd::atomic_ghost::*;
 
@@ -71,7 +71,7 @@ pub struct LL {
     data: Ghost<LLData>,
 
     // first to be popped off goes at the end
-    perms: Tracked<Map<nat, (PointsTo<Node>, PointsToRaw, Mim::block, IsExposed)>>,
+    perms: Tracked<IMap<nat, (PointsTo<Node>, PointsToRaw, Mim::block, IsExposed)>>,
 }
 
 pub tracked struct LLGhostStateToReconvene {
@@ -79,7 +79,7 @@ pub tracked struct LLGhostStateToReconvene {
     pub ghost page_id: PageId,
     pub ghost instance: Mim::Instance,
 
-    pub tracked map: Map<nat, (PointsToRaw, Mim::block)>,
+    pub tracked map: IMap<nat, (PointsToRaw, Mim::block)>,
 }
 
 impl LL {
@@ -194,7 +194,7 @@ impl LL {
             block_size_ge_word();
             block_ptr_aligned_to_word();
 
-            let tracked (m1, m2) = points_to_raw.split(set_int_range(ptr as int, ptr as int + size_of::<Node>() as int));
+            let tracked (m1, m2) = points_to_raw.split(Set::<int>::range(ptr as int, ptr as int + size_of::<Node>() as int));
             mem1 = m1.into_typed::<Node>(ptr.addr());
             mem2 = m2;
         }
@@ -447,11 +447,11 @@ impl LL {
             points_to.ptr() == ptr
               && points_to.opt_value() == MemContents::Init(Node { ptr: next })
 
-              && points_to_raw.dom() == perm.dom().difference(set_int_range(ptr as int, ptr as int + size_of::<Node>()))
+              && points_to_raw.dom() == perm.dom().difference(vstd::set_lib::set_int_range(ptr as int, ptr as int + size_of::<Node>()))
               && points_to_raw.provenance() == ptr@.provenance
         }),
     {
-        let tracked (points_to, rest) = perm.split(set_int_range(ptr as int, ptr as int + size_of::<Node>()));
+        let tracked (points_to, rest) = perm.split(vstd::set_lib::set_int_range(ptr as int, ptr as int + size_of::<Node>()));
         
         vstd::layout::layout_for_type_is_valid::<Node>(); // $line_count$Proof$
         let tracked mut points_to_node = points_to.into_typed::<Node>(ptr.addr());
@@ -479,7 +479,7 @@ impl LL {
             data: Ghost(LLData {
                 fixed_page, block_size, page_id, instance, len: 0, heap_id,
             }),
-            perms: Tracked(Map::tracked_empty()),
+            perms: Tracked(IMap::tracked_empty()),
         }
     }
 
@@ -614,13 +614,13 @@ impl LL {
             self.data@.len = self.data@.len + other.data@.len;
             other.data@.len = 0;
 
-            let tracked mut other_map = Map::tracked_empty();
+            let tracked mut other_map = IMap::tracked_empty();
             tracked_swap(other.perms.borrow_mut(), &mut other_map);
 
-            let tracked mut self_map = Map::tracked_empty();
+            let tracked mut self_map = IMap::tracked_empty();
             tracked_swap(self.perms.borrow_mut(), &mut self_map);
 
-            let key_map = Map::<nat, nat>::new(
+            let key_map = IMap::<nat, nat>::new(
                     |i: nat| self_len <= i < self_len + other_len,
                     |i: nat| (i - self_len) as nat,
                 );
@@ -690,7 +690,7 @@ impl LL {
         Ghost(extend): Ghost<nat>,  // spec we're extending to
 
         Tracked(points_to_raw_r): Tracked<&mut PointsToRaw>,
-        Tracked(tokens): Tracked<&mut Map<int, Mim::block>>,
+        Tracked(tokens): Tracked<&mut IMap<int, Mim::block>>,
     )
         requires
             old(self).wf(),
@@ -739,7 +739,7 @@ impl LL {
         // based on mi_page_free_list_extend
 
         let tracked mut points_to_raw = PointsToRaw::empty(start@.provenance);
-        let tracked mut new_map: Map<nat, (PointsTo<Node>, PointsToRaw, Mim::block, IsExposed)> = Map::tracked_empty();
+        let tracked mut new_map: IMap<nat, (PointsTo<Node>, PointsToRaw, Mim::block, IsExposed)> = IMap::tracked_empty();
         proof {
             tracked_swap(&mut points_to_raw, points_to_raw_r);
         }
@@ -803,8 +803,8 @@ impl LL {
 
             let next: *mut Node = start.with_addr(block + bsize) as *mut Node;
 
-            let tracked (points_to, rest) = points_to_raw.split(set_int_range(block as int, block as int + bsize as int));
-            let tracked (points_to1, points_to2) = points_to.split(set_int_range(block as int, block as int + size_of::<Node>() as int));
+            let tracked (points_to, rest) = points_to_raw.split(Set::<int>::range(block as int, block as int + bsize as int));
+            let tracked (points_to1, points_to2) = points_to.split(Set::<int>::range(block as int, block as int + size_of::<Node>() as int));
             vstd::layout::layout_for_type_is_valid::<Node>(); // $line_count$Proof$
             let tracked mut points_to_node = points_to1.into_typed::<Node>(block);
 
@@ -878,8 +878,8 @@ impl LL {
             }
         }
 
-        let tracked (points_to, rest) = points_to_raw.split(set_int_range(block as int, block as int + bsize as int));
-        let tracked (points_to1, points_to2) = points_to.split(set_int_range(block as int, block as int + size_of::<Node>() as int));
+        let tracked (points_to, rest) = points_to_raw.split(Set::<int>::range(block as int, block as int + bsize as int));
+        let tracked (points_to1, points_to2) = points_to.split(Set::<int>::range(block as int, block as int + size_of::<Node>() as int));
         proof { points_to_raw = rest; }
         vstd::layout::layout_for_type_is_valid::<Node>(); // $line_count$Proof$
         let tracked mut points_to_node = points_to1.into_typed::<Node>(block);
@@ -1003,7 +1003,7 @@ impl LL {
 
             let len = self.data@.len;
             self.data@.len = 0;
-            let tracked mut m = Map::tracked_empty();
+            let tracked mut m = IMap::tracked_empty();
             tracked_swap(&mut m, self.perms.borrow_mut());
 
             assert forall |i: nat| (#[trigger] m.dom().contains(i) <==> 0 <= i < len)
@@ -1039,12 +1039,12 @@ impl LL {
     }
 
     pub proof fn convene_pt_map(
-        tracked m: Map<nat, (PointsTo<Node>, PointsToRaw, Mim::block, IsExposed)>,
+        tracked m: IMap<nat, (PointsTo<Node>, PointsToRaw, Mim::block, IsExposed)>,
         len: nat,
         instance: Mim::Instance,
         page_id: PageId,
         block_size: nat,
-    ) -> (tracked m2: Map<nat, (PointsToRaw, Mim::block)>)
+    ) -> (tracked m2: IMap<nat, (PointsToRaw, Mim::block)>)
         requires
             forall |i: nat| (#[trigger] m.dom().contains(i) <==> 0 <= i < len)
               && (m.dom().contains(i) ==> ({
@@ -1077,8 +1077,8 @@ impl LL {
         decreases len,
     {
         if len == 0 {
-            let tracked m = Map::tracked_empty();
-            assert(m.dom() =~= Set::empty());
+            let tracked m = IMap::tracked_empty();
+            assert(m.dom() =~= ISet::empty());
             assert(m.len() == 0);
             m
         } else {
@@ -1107,7 +1107,7 @@ impl LL {
         tracked llgstr1: LLGhostStateToReconvene,
         tracked llgstr2: LLGhostStateToReconvene,
         n_blocks: int,
-    ) -> (tracked res: (PointsToRaw, Map<BlockId, Mim::block>))
+    ) -> (tracked res: (PointsToRaw, IMap<BlockId, Mim::block>))
         requires
             llgstr_wf(llgstr1),
             llgstr_wf(llgstr2),
@@ -1134,7 +1134,7 @@ impl LL {
         }})
     {
         let tracked llgstr = Self::llgstr_merge(llgstr1, llgstr2);
-        let idxmap = Map::<nat, nat>::new(
+        let idxmap = IMap::<nat, nat>::new(
             |p| llgstr.map.dom().contains(p),
             |p| llgstr.map[p].1.key().idx);
         if exists |p| llgstr.map.dom().contains(p) && !(0 <= idxmap[p] < n_blocks) {
@@ -1180,7 +1180,7 @@ impl LL {
     {
         let tracked LLGhostStateToReconvene { map: mut map1, .. } = llgstr1;
         let tracked LLGhostStateToReconvene { map: mut map2, .. } = llgstr2;
-        map2.tracked_map_keys_in_place(Map::<nat, nat>::new(
+        map2.tracked_map_keys_in_place(IMap::<nat, nat>::new(
             |k: nat| map1.len() <= k < map1.len() + map2.len(),
             |k: nat| (k - map1.len()) as nat,
         ));
@@ -1231,12 +1231,12 @@ impl LL {
     }
 
     pub proof fn reconvene_rec(
-        tracked m: Map<nat, (PointsToRaw, Mim::block)>,
+        tracked m: IMap<nat, (PointsToRaw, Mim::block)>,
         len: nat,
         instance: Mim::Instance,
         page_id: PageId,
         block_size: nat,
-    ) -> (tracked res: (PointsToRaw, Map<BlockId, Mim::block>))
+    ) -> (tracked res: (PointsToRaw, IMap<BlockId, Mim::block>))
         requires
             forall |j: nat| 0 <= j < len ==> #[trigger] has_idx(m, j),
             forall |i: nat|
@@ -1267,7 +1267,7 @@ impl LL {
         decreases len,
     {
         if len == 0 {
-            (PointsToRaw::empty(page_id.segment_id.provenance), Map::tracked_empty())
+            (PointsToRaw::empty(page_id.segment_id.provenance), IMap::tracked_empty())
         } else {
             let j = (len - 1) as nat;
             assert(has_idx(m, j));
@@ -1299,12 +1299,12 @@ impl LL {
     }
 }
 
-pub closed spec fn has_idx(map: Map<nat, (PointsToRaw, Mim::block)>, i: nat) -> bool {
+pub closed spec fn has_idx(map: IMap<nat, (PointsToRaw, Mim::block)>, i: nat) -> bool {
     exists |p: nat| map.dom().contains(p) && map[p].1.key().idx == i
 }
 
-pub open spec fn set_nat_range(lo: nat, hi: nat) -> Set<nat> {
-    Set::new(|i: nat| lo <= i && i < hi)
+pub open spec fn set_nat_range(lo: nat, hi: nat) -> ISet<nat> {
+    ISet::new(|i: nat| lo <= i && i < hi)
 }
 
 pub proof fn lemma_nat_range(lo: nat, hi: nat)
@@ -1317,7 +1317,7 @@ pub proof fn lemma_nat_range(lo: nat, hi: nat)
         hi - lo,
 {
     if lo == hi {
-        assert(set_nat_range(lo, hi) =~= Set::empty());
+        assert(set_nat_range(lo, hi) =~= ISet::empty());
     } else {
         lemma_nat_range(lo, (hi - 1) as nat);
         assert(set_nat_range(lo, (hi - 1) as nat).insert((hi - 1) as nat) =~= set_nat_range(lo, hi));
@@ -1376,7 +1376,7 @@ pub fn bound_on_2_lists(
         let n_blocks = thread_token.value().pages[ll1.page_id()].num_blocks;
         if ll1.len() + ll2.len() > n_blocks {
             let len = ll1.len();
-            let tracked mut m = Map::tracked_empty();
+            let tracked mut m = IMap::tracked_empty();
             tracked_swap(&mut m, ll1.perms.borrow_mut());
             assert forall |i: nat| (#[trigger] m.dom().contains(i) <==> 0 <= i < len)
             by {
@@ -1389,7 +1389,7 @@ pub fn bound_on_2_lists(
             let tracked llgstr1 = LLGhostStateToReconvene { map: map, block_size, page_id, instance };
 
             let len = ll2.len();
-            let tracked mut m = Map::tracked_empty();
+            let tracked mut m = IMap::tracked_empty();
             tracked_swap(&mut m, ll2.perms.borrow_mut());
             assert forall |i: nat| (#[trigger] m.dom().contains(i) <==> 0 <= i < len)
             by {
@@ -1404,7 +1404,7 @@ pub fn bound_on_2_lists(
             let tracked llgstr = LL::llgstr_merge(llgstr1, llgstr2);
             let tracked LLGhostStateToReconvene { map: mut map, .. } = llgstr;
 
-            let idxmap = Map::<nat, nat>::new(
+            let idxmap = IMap::<nat, nat>::new(
                 |p| map.dom().contains(p),
                 |p| map[p].1.key().idx);
             if exists |p| map.dom().contains(p) && !(0 <= idxmap[p] < n_blocks) {
@@ -1448,7 +1448,7 @@ pub fn bound_on_1_lists(
         let n_blocks = thread_token.value().pages[ll1.page_id()].num_blocks;
         if ll1.len() > n_blocks {
             let len = ll1.len();
-            let tracked mut m = Map::tracked_empty();
+            let tracked mut m = IMap::tracked_empty();
             tracked_swap(&mut m, ll1.perms.borrow_mut());
 
             assert forall |i: nat| (#[trigger] m.dom().contains(i) <==> 0 <= i < len)
@@ -1461,7 +1461,7 @@ pub fn bound_on_1_lists(
 
             let tracked mut map = LL::convene_pt_map(m, len, instance, page_id, block_size);
 
-            let idxmap = Map::<nat, nat>::new(
+            let idxmap = IMap::<nat, nat>::new(
                 |p| map.dom().contains(p),
                 |p| map[p].1.key().idx);
             if exists |p| map.dom().contains(p) && !(0 <= idxmap[p] < n_blocks) {
@@ -1523,7 +1523,7 @@ impl ThreadLLSimple {
         Self {
             instance: Ghost(instance),
             heap_id: Ghost(heap_id),
-            atomic: AtomicPtr::new(Ghost((Ghost(instance), Ghost(heap_id))), core::ptr::null_mut(), Tracked(Tracked(LL { first: p, data: Ghost(LLData { fixed_page: false, block_size: arbitrary(), page_id: arbitrary(), instance, len: 0, heap_id: Some(heap_id), }), perms: Tracked(Map::tracked_empty()), })),),
+            atomic: AtomicPtr::new(Ghost((Ghost(instance), Ghost(heap_id))), core::ptr::null_mut(), Tracked(Tracked(LL { first: p, data: Ghost(LLData { fixed_page: false, block_size: arbitrary(), page_id: arbitrary(), instance, len: 0, heap_id: Some(heap_id), }), perms: Tracked(IMap::tracked_empty()), })),),
         }
     }
 
@@ -1625,7 +1625,7 @@ impl ThreadLLSimple {
                 let tracked new_ll = LL {
                     first: p,
                     data: Ghost(data),
-                    perms: Tracked(Map::tracked_empty()),
+                    perms: Tracked(IMap::tracked_empty()),
                 };
                 g = Tracked(new_ll);
             }
@@ -1812,7 +1812,7 @@ impl ThreadLLWithDelayBits {
         let tracked new_ll = LL {
             first: p,
             data: Ghost(data),
-            perms: Tracked(Map::tracked_empty()),
+            perms: Tracked(IMap::tracked_empty()),
         };
         atomic_with_ghost!(
             &self.atomic => no_op();
@@ -2061,7 +2061,7 @@ impl ThreadLLWithDelayBits {
                 let tracked new_ll = LL {
                     first: p,
                     data: Ghost(data),
-                    perms: Tracked(Map::tracked_empty()),
+                    perms: Tracked(IMap::tracked_empty()),
                 };
                 g = (emp_token, Some((delay, new_ll)));
 

--- a/verus-mimalloc/os_commit.rs
+++ b/verus-mimalloc/os_commit.rs
@@ -1,12 +1,11 @@
 use core::intrinsics::{unlikely, likely};
 use vstd::prelude::*;
-use vstd::set_lib::*;
+use vstd::iset_lib::*;
 use vstd::raw_ptr::*;
 use crate::config::*;
 use crate::os_mem::*;
 use crate::layout::*;
 use crate::types::todo;
-use vstd::set_lib::set_int_range;
 
 
 verus!{
@@ -53,7 +52,7 @@ pub fn os_decommit(addr: *mut u8, size: usize, Tracked(mem): Tracked<&mut MemChu
         mem.os_rw_bytes().subset_of(old(mem).os_rw_bytes()),
         mem.points_to.provenance() == old(mem).points_to.provenance(),
 
-        old(mem).points_to.dom() - mem.points_to.dom()
+        old(mem).points_to.dom().to_iset() - mem.points_to.dom().to_iset()
             =~= old(mem).os_rw_bytes() - mem.os_rw_bytes(),
         old(mem).os_rw_bytes() - mem.os_rw_bytes()
             <= set_int_range(addr as int, addr as int + size),
@@ -76,7 +75,7 @@ pub fn os_decommit(addr: *mut u8, size: usize, Tracked(mem): Tracked<&mut MemChu
                 assert(old(mem).os_rw_bytes().contains(p));
             }
         }
-        assert_sets_equal!(old(mem).points_to.dom() - mem.points_to.dom(),
+        assert_isets_equal!(old(mem).points_to.dom().to_iset() - mem.points_to.dom().to_iset(),
             old(mem).os_rw_bytes() - mem.os_rw_bytes(),
             p =>
         {
@@ -161,8 +160,9 @@ fn os_commitx(
         commit ==> res.0 ==> mem.os_has_range_read_write(addr as int, size as int),
         !commit ==> mem.points_to.dom().subset_of(old(mem).points_to.dom()),
         !commit ==> mem.os_rw_bytes().subset_of(old(mem).os_rw_bytes()),
-        !commit ==> old(mem).points_to.dom() - mem.points_to.dom()
-                    =~= old(mem).os_rw_bytes() - mem.os_rw_bytes(),
+        !commit ==> (old(mem).points_to.dom() - mem.points_to.dom()).congruent(
+            old(mem).os_rw_bytes() - mem.os_rw_bytes()
+        ),
         mem.points_to.provenance() == old(mem).points_to.provenance()
 {
     let is_zero = false;
@@ -175,7 +175,7 @@ fn os_commitx(
     let p = addr.with_addr(start);
 
     let tracked weird_extra = mem.take_points_to_set(
-          mem.points_to.dom() - mem.os_rw_bytes());
+          mem.points_to.dom() - mem.os_rw_bytes().to_set().unwrap());
     let tracked mut exact_mem = mem.split(addr as int, size as int);
     let ghost em = exact_mem;
 
@@ -199,7 +199,7 @@ fn os_commitx(
                 =~= set_int_range(addr as int, addr + size as int));
 
             assert(exact_mem.range_os_rw().disjoint(exact_mem.range_os_none()));
-            assert(exact_mem.os_rw_bytes() =~= Set::empty());
+            assert(exact_mem.os_rw_bytes() =~= ISet::empty());
 
             assert(em.os_rw_bytes() - exact_mem.os_rw_bytes()
                 =~= set_int_range(addr as int, addr + size as int));
@@ -209,6 +209,14 @@ fn os_commitx(
             assert(old(mem).os_rw_bytes() - mem.os_rw_bytes()
                 =~= set_int_range(addr as int, addr + size as int));
             */
+
+            assert(exact_mem.range_os_rw().disjoint(exact_mem.range_os_none()));
+            assert(exact_mem.os_rw_bytes() =~= ISet::empty());
+
+//assert(old(mem).points_to.dom().to_iset() - mem.points_to.dom().to_iset()
+//    =~= set_int_range(addr as int, addr as int + size as int));
+//assert(old(mem).os_rw_bytes() - mem.os_rw_bytes()
+//    =~= set_int_range(addr as int, addr as int + size as int));
         }
         assert(mem.os.dom() =~= old(mem).os.dom());
     }

--- a/verus-mimalloc/os_commit.rs
+++ b/verus-mimalloc/os_commit.rs
@@ -174,50 +174,65 @@ fn os_commitx(
 
     let p = addr.with_addr(start);
 
-    let tracked weird_extra = mem.take_points_to_set(
-          mem.points_to.dom() - mem.os_rw_bytes().to_set().unwrap());
     let tracked mut exact_mem = mem.split(addr as int, size as int);
     let ghost em = exact_mem;
 
     if commit {
         mprotect_prot_read_write(p, csize, Tracked(&mut exact_mem));
+        proof {
+            mem.join(exact_mem);
+        }
     } else {
-        // TODO madvise?
+        // Take out points_to NOT in os_rw, so has_pointsto_for_all_read_write holds
+        let tracked weird_extra = exact_mem.take_points_to_set(
+              exact_mem.points_to.dom().filter(
+                  |x: int| !exact_mem.os_rw_bytes().contains(x)));
+
+        proof {
+            assert forall |a: int| exact_mem.range_os_rw().contains(a)
+                implies exact_mem.range_points_to().contains(a)
+            by {
+                assert(em.os.dom().contains(a));
+                assert(set_int_range(addr as int, addr as int + size as int).contains(a));
+                assert(old(mem).points_to.dom().contains(a));
+                assert(em.points_to.dom().contains(a));
+                assert(em.os_rw_bytes().contains(a));
+            }
+            assert(exact_mem.has_pointsto_for_all_read_write());
+        }
+
         mprotect_prot_none(p, csize, Tracked(&mut exact_mem));
+
+        proof {
+            exact_mem.give_points_to_range(weird_extra);
+            mem.join(exact_mem);
+
+            assert forall |a: int|
+                (old(mem).points_to.dom() - mem.points_to.dom()).contains(a)
+                <==> (old(mem).os_rw_bytes() - mem.os_rw_bytes()).contains(a)
+            by {
+                if (old(mem).points_to.dom() - mem.points_to.dom()).contains(a) {
+                    assert(vstd::set_lib::set_int_range(
+                        addr as int, addr as int + size as int).contains(a));
+                    assert(em.points_to.dom().contains(a));
+                    assert(em.os_rw_bytes().contains(a));
+                    assert(old(mem).os_rw_bytes().contains(a));
+                }
+                if (old(mem).os_rw_bytes() - mem.os_rw_bytes()).contains(a) {
+                    assert(old(mem).os.dom().contains(a));
+                    if !set_int_range(addr as int, addr as int + size as int).contains(a) {
+                        assert(mem.os_rw_bytes().contains(a));
+                    }
+                    assert(set_int_range(addr as int, addr as int + size as int).contains(a));
+                    assert(old(mem).points_to.dom().contains(a));
+                    assert(em.points_to.dom().contains(a));
+                    assert(em.os_rw_bytes().contains(a));
+                }
+            }
+        }
     }
 
     proof {
-        mem.join(exact_mem);
-        mem.give_points_to_range(weird_extra);
-        //assert( mem.os.dom() == old(mem).os.dom(),
-        if commit {
-        }
-        if !commit {
-            /*assert(em.points_to.dom()
-                =~= set_int_range(addr as int, addr + size as int));
-            assert(em.points_to.dom() - exact_mem.points_to.dom()
-                =~= set_int_range(addr as int, addr + size as int));
-
-            assert(exact_mem.range_os_rw().disjoint(exact_mem.range_os_none()));
-            assert(exact_mem.os_rw_bytes() =~= ISet::empty());
-
-            assert(em.os_rw_bytes() - exact_mem.os_rw_bytes()
-                =~= set_int_range(addr as int, addr + size as int));
-
-            assert(old(mem).points_to.dom() - mem.points_to.dom()
-                =~= set_int_range(addr as int, addr + size as int));
-            assert(old(mem).os_rw_bytes() - mem.os_rw_bytes()
-                =~= set_int_range(addr as int, addr + size as int));
-            */
-
-            assert(exact_mem.range_os_rw().disjoint(exact_mem.range_os_none()));
-            assert(exact_mem.os_rw_bytes() =~= ISet::empty());
-
-//assert(old(mem).points_to.dom().to_iset() - mem.points_to.dom().to_iset()
-//    =~= set_int_range(addr as int, addr as int + size as int));
-//assert(old(mem).os_rw_bytes() - mem.os_rw_bytes()
-//    =~= set_int_range(addr as int, addr as int + size as int));
-        }
         assert(mem.os.dom() =~= old(mem).os.dom());
     }
 

--- a/verus-mimalloc/os_mem.rs
+++ b/verus-mimalloc/os_mem.rs
@@ -1,6 +1,6 @@
 use vstd::prelude::*;
 use vstd::raw_ptr::*;
-use vstd::set_lib::*;
+use vstd::iset_lib::*;
 use libc::{PROT_NONE, PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS, MAP_NORESERVE};
 
 verus!{
@@ -33,7 +33,7 @@ pub ghost struct OsMemData {
 
 #[verus::trusted]
 pub tracked struct MemChunk {
-    pub os: Map<int, OsMem>,
+    pub os: IMap<int, OsMem>,
     pub points_to: PointsToRaw,
 }
 
@@ -50,23 +50,21 @@ impl MemChunk {
     }
 
     #[verifier::inline]
-    pub open spec fn range_os(&self) -> Set<int> {
+    pub open spec fn range_os(&self) -> ISet<int> {
         self.os.dom()
     }
 
-    pub open spec fn range_os_rw(&self) -> Set<int> {
-        Set::<int>::new(|addr| self.os.dom().contains(addr) && self.os[addr]@.mem_protect
-          == MemProtect { read: true, write: true })
+    pub open spec fn range_os_rw(&self) -> ISet<int> {
+        self.os.dom().filter(|addr| self.os[addr]@.mem_protect == MemProtect { read: true, write: true })
     }
 
-    pub open spec fn range_os_none(&self) -> Set<int> {
-        Set::<int>::new(|addr| self.os.dom().contains(addr) && self.os[addr]@.mem_protect
-          == MemProtect { read: false, write: false })
+    pub open spec fn range_os_none(&self) -> ISet<int> {
+        self.os.dom().filter(|addr| self.os[addr]@.mem_protect == MemProtect { read: false, write: false })
     }
 
     #[verifier::inline]
-    pub open spec fn range_points_to(&self) -> Set<int> {
-        self.points_to.dom()
+    pub open spec fn range_points_to(&self) -> ISet<int> {
+        self.points_to.dom().to_iset()
     }
 
     pub open spec fn has_pointsto_for_all_read_write(&self) -> bool {

--- a/verus-mimalloc/os_mem_util.rs
+++ b/verus-mimalloc/os_mem_util.rs
@@ -1,5 +1,5 @@
 use vstd::prelude::*;
-use vstd::set_lib::*;
+use vstd::iset_lib::*;
 use vstd::raw_ptr::*;
 use vstd::modes::*;
 
@@ -15,7 +15,7 @@ verus!{
 impl MemChunk {
     pub proof fn empty() -> (tracked mc: MemChunk)
     {
-       MemChunk { os: Map::tracked_empty(), points_to: PointsToRaw::empty(Provenance::null()) }
+       MemChunk { os: IMap::tracked_empty(), points_to: PointsToRaw::empty(Provenance::null()) }
     }
 
     #[verifier::inline]
@@ -23,7 +23,7 @@ impl MemChunk {
         set_int_range(start, start + len) <= self.range_points_to()
     }
 
-    pub open spec fn os_rw_bytes(&self) -> Set<int> {
+    pub open spec fn os_rw_bytes(&self) -> ISet<int> {
         self.range_os_rw()
     }
 
@@ -37,9 +37,10 @@ impl MemChunk {
         len: int
     ) -> (tracked t: Self)
         ensures
-            t.points_to.dom() == old(self).points_to.dom().intersect(set_int_range(start, start + len)),
+            t.points_to.dom().to_iset() == old(self).points_to.dom().to_iset().intersect(set_int_range(start, start + len)),
+t.points_to.dom().to_iset() == old(self).points_to.dom().to_iset().intersect(set_int_range(start, start + len)),
             t.os == old(self).os.restrict(set_int_range(start, start + len)),
-            self.points_to.dom() == old(self).points_to.dom().difference(set_int_range(start, start + len)),
+            self.points_to.dom() == old(self).points_to.dom().difference(vstd::set_lib::set_int_range(start, start + len)),
             self.os == old(self).os.remove_keys(set_int_range(start, start + len)),
             self.points_to.provenance() == old(self).points_to.provenance(),
             self.points_to.provenance() == t.points_to.provenance(),
@@ -50,14 +51,14 @@ impl MemChunk {
 
         let tracked mut pt = PointsToRaw::empty(self.points_to.provenance());
         tracked_swap(&mut pt, &mut self.points_to);
-        let tracked (rt, pt) = pt.split(set_int_range(start, start + len).intersect(pt.dom()));
+        let tracked (rt, pt) = pt.split(Set::<int>::range(start, start + len).intersect(pt.dom()));
         self.points_to = pt;
 
         let tracked t = MemChunk { os: split_os, points_to: rt };
 
-        assert(self.points_to.dom() =~= old(self).points_to.dom().difference(set_int_range(start, start + len)));
+        assert(self.points_to.dom() =~= old(self).points_to.dom().difference(vstd::set_lib::set_int_range(start, start + len)));
         assert(self.os =~= old(self).os.remove_keys(set_int_range(start, start + len)));
-        assert(t.points_to.dom() =~= old(self).points_to.dom().intersect(set_int_range(start, start + len)));
+        assert(t.points_to.dom() =~= old(self).points_to.dom().intersect(vstd::set_lib::set_int_range(start, start + len)));
         assert(t.os =~= old(self).os.restrict(set_int_range(start, start + len)));
 
         t
@@ -101,7 +102,7 @@ impl MemChunk {
         s: Set<int>,
     ) -> (tracked points_to: PointsToRaw)
         requires 
-            s <= old(self).points_to.dom()
+            s <= old(self).points_to.dom(),
         ensures
             self.os == old(self).os,
             self.points_to.dom() == old(self).points_to.dom().difference(s),
@@ -127,7 +128,7 @@ impl MemChunk {
             old(self).pointsto_has_range(start, len),
         ensures
             self.os == old(self).os,
-            self.points_to.dom() == old(self).points_to.dom().difference(set_int_range(start, start+len)),
+            self.points_to.dom() == old(self).points_to.dom().difference(vstd::set_lib::set_int_range(start, start+len)),
             self.points_to.provenance() == old(self).points_to.provenance(),
             points_to.is_range(start, len),
             points_to.provenance() == old(self).points_to.provenance(),
@@ -135,7 +136,7 @@ impl MemChunk {
     {
         let tracked mut pt = PointsToRaw::empty(self.points_to.provenance());
         tracked_swap(&mut pt, &mut self.points_to);
-        let tracked (rt, pt) = pt.split(set_int_range(start, start + len));
+        let tracked (rt, pt) = pt.split(Set::<int>::range(start, start + len));
         self.points_to = pt;
         rt
     }
@@ -162,7 +163,7 @@ impl MemChunk {
     }
 }
 
-pub open spec fn segment_info_range(segment_id: SegmentId) -> Set<int> {
+pub open spec fn segment_info_range(segment_id: SegmentId) -> ISet<int> {
     set_int_range(segment_start(segment_id),
         segment_start(segment_id) + SIZEOF_SEGMENT_HEADER + SIZEOF_PAGE_HEADER * (SLICES_PER_SEGMENT + 1)
     )
@@ -171,10 +172,10 @@ pub open spec fn segment_info_range(segment_id: SegmentId) -> Set<int> {
 pub open spec fn mem_chunk_good1(
     mem: MemChunk,
     segment_id: SegmentId,
-    commit_bytes: Set<int>,
-    decommit_bytes: Set<int>,
-    pages_range_total: Set<int>,
-    pages_used_total: Set<int>,
+    commit_bytes: ISet<int>,
+    decommit_bytes: ISet<int>,
+    pages_range_total: ISet<int>,
+    pages_used_total: ISet<int>,
 ) -> bool {
     &&& mem.wf()
     &&& mem.os_exact_range(segment_start(segment_id), SEGMENT_SIZE as int)
@@ -187,13 +188,13 @@ pub open spec fn mem_chunk_good1(
     &&& pages_used_total <= commit_bytes - decommit_bytes
 
     &&& mem.os_rw_bytes() <=
-          mem.points_to.dom()
+          mem.points_to.dom().to_iset()
             + segment_info_range(segment_id)
             + pages_range_total
 }
 
 impl Local {
-    spec fn segment_page_range(&self, segment_id: SegmentId, page_id: PageId) -> Set<int> {
+    spec fn segment_page_range(&self, segment_id: SegmentId, page_id: PageId) -> ISet<int> {
         if page_id.segment_id == segment_id && self.is_used_primary(page_id) {
             set_int_range(
                 page_start(page_id) + start_offset(self.block_size(page_id)),
@@ -201,34 +202,34 @@ impl Local {
                     + self.page_capacity(page_id) * self.block_size(page_id)
             )
         } else {
-            Set::empty()
+            ISet::empty()
         }
     }
 
-    pub closed spec fn segment_pages_range_total(&self, segment_id: SegmentId) -> Set<int> {
-        Set::<int>::new(|addr| exists |page_id|
+    pub closed spec fn segment_pages_range_total(&self, segment_id: SegmentId) -> ISet<int> {
+        ISet::<int>::new(|addr| exists |page_id|
             self.segment_page_range(segment_id, page_id).contains(addr)
         )
     }
 
-    spec fn segment_page_used(&self, segment_id: SegmentId, page_id: PageId) -> Set<int> {
+    spec fn segment_page_used(&self, segment_id: SegmentId, page_id: PageId) -> ISet<int> {
         if page_id.segment_id == segment_id && self.is_used_primary(page_id) {
             set_int_range(
                 page_start(page_id),
                 page_start(page_id) + self.page_count(page_id) * SLICE_SIZE
             )
         } else {
-            Set::empty()
+            ISet::empty()
         }
     }
 
-    pub closed spec fn segment_pages_used_total(&self, segment_id: SegmentId) -> Set<int> {
-        Set::<int>::new(|addr| exists |page_id|
+    pub closed spec fn segment_pages_used_total(&self, segment_id: SegmentId) -> ISet<int> {
+        ISet::<int>::new(|addr| exists |page_id|
             self.segment_page_used(segment_id, page_id).contains(addr)
         )
     }
 
-    /*spec fn segment_page_range_reserved(&self, segment_id: SegmentId, page_id: PageId) -> Set<int> {
+    /*spec fn segment_page_range_reserved(&self, segment_id: SegmentId, page_id: PageId) -> ISet<int> {
         if page_id.segment_id == segment_id && self.is_used_primary(page_id) {
             set_int_range(
                 page_start(page_id) + start_offset(self.block_size(page_id)),
@@ -236,12 +237,12 @@ impl Local {
                     + self.page_reserved(page_id) * self.block_size(page_id)
             )
         } else {
-            Set::empty()
+            ISet::empty()
         }
     }
 
-    spec fn segment_pages_range_reserved_total(&self, segment_id: SegmentId) -> Set<int> {
-        Set::<int>::new(|addr| exists |page_id|
+    spec fn segment_pages_range_reserved_total(&self, segment_id: SegmentId) -> ISet<int> {
+        ISet::<int>::new(|addr| exists |page_id|
             self.segment_page_range_reserved(segment_id, page_id).contains(addr)
         )
     }*/
@@ -289,7 +290,7 @@ pub proof fn decommit_subset_of_pointsto(local: Local, sid: SegmentId)
         local.mem_chunk_good(sid),
     ensures
         local.decommit_mask(sid).bytes(sid) <= 
-            local.segments[sid].mem.points_to.dom()
+            local.segments[sid].mem.points_to.dom().to_iset()
 {
     range_total_le_used_total(local, sid);
 }
@@ -421,7 +422,7 @@ pub proof fn preserves_mem_chunk_good_except(local1: Local, local2: Local, esegm
         }
         assert(pages_range_total1.subset_of(pages_range_total2));
         assert(mem.os_rw_bytes().subset_of(
-              mem.points_to.dom()
+              mem.points_to.dom().to_iset()
                 + segment_info_range(sid)
                 + pages_range_total2
         ));
@@ -444,7 +445,7 @@ pub proof fn empty_segment_pages_used_total(local1: Local, sid: SegmentId)
     requires
         forall |pid: PageId| pid.segment_id == sid ==> !local1.is_used_primary(pid),
     ensures
-        local1.segment_pages_used_total(sid) =~= Set::empty(),
+        local1.segment_pages_used_total(sid) =~= ISet::empty(),
 {
 }
 
@@ -536,8 +537,8 @@ pub proof fn preserves_mem_chunk_good_on_decommit(local1: Local, local2: Local, 
               (local1.decommit_mask(sid).bytes(sid) - local2.decommit_mask(sid).bytes(sid)),
 
         local2.segments[sid].mem.os_rw_bytes() <= local1.segments[sid].mem.os_rw_bytes(),
-        local2.segments[sid].mem.points_to.dom() =~=
-            local1.segments[sid].mem.points_to.dom() -
+        local2.segments[sid].mem.points_to.dom().to_iset() =~=
+            local1.segments[sid].mem.points_to.dom().to_iset() -
               (local1.segments[sid].mem.os_rw_bytes() - local2.segments[sid].mem.os_rw_bytes()),
 
         (local1.segments[sid].mem.os_rw_bytes() - local2.segments[sid].mem.os_rw_bytes())
@@ -600,9 +601,9 @@ pub proof fn preserves_mem_chunk_good_on_commit_with_mask_set(local1: Local, loc
         assert(local2.segment_page_range(sid, page_id).contains(addr));
     }
     assert(pages_range_total1.subset_of(pages_range_total2));
-    assert((mem.os_rw_bytes() - old_mem.os_rw_bytes()).subset_of(mem.points_to.dom()));
+    assert((mem.os_rw_bytes() - old_mem.os_rw_bytes()).subset_of(mem.points_to.dom().to_iset()));
     assert(mem.os_rw_bytes().subset_of(
-          mem.points_to.dom()
+          mem.points_to.dom().to_iset()
             + segment_info_range(sid)
             + pages_range_total2
     ));
@@ -643,8 +644,8 @@ pub proof fn preserves_mem_chunk_good_on_transfer_to_capacity(local1: Local, loc
                     + start_offset(local1.block_size(page_id))
                     + local2.page_capacity(page_id) * local1.block_size(page_id),
             );
-          local2.segments[page_id.segment_id].mem.points_to.dom() =~=
-              local1.segments[page_id.segment_id].mem.points_to.dom() - sr
+          local2.segments[page_id.segment_id].mem.points_to.dom().to_iset() =~=
+              local1.segments[page_id.segment_id].mem.points_to.dom().to_iset() - sr
           //&& local2.decommit_mask(page_id.segment_id).bytes(page_id.segment_id).disjoint(sr)
         }),
     ensures local2.mem_chunk_good(page_id.segment_id),
@@ -703,7 +704,7 @@ pub proof fn preserves_mem_chunk_good_on_transfer_to_capacity(local1: Local, loc
     preserves_segment_pages_used_total(local1, local2, page_id.segment_id);
 
     assert(mem.os_rw_bytes().subset_of(
-          mem.points_to.dom()
+          mem.points_to.dom().to_iset()
             + segment_info_range(sid)
             + pages_range_total2
     ));
@@ -741,8 +742,8 @@ pub proof fn preserves_mem_chunk_good_on_transfer_back(local1: Local, local2: Lo
 
         local2.segments[page_id.segment_id].mem.os
           == local1.segments[page_id.segment_id].mem.os,
-        local2.segments[page_id.segment_id].mem.points_to.dom() =~=
-            local1.segments[page_id.segment_id].mem.points_to.dom() +
+        local2.segments[page_id.segment_id].mem.points_to.dom().to_iset() =~=
+            local1.segments[page_id.segment_id].mem.points_to.dom().to_iset() +
             set_int_range(
                 page_start(page_id)
                     + start_offset(local1.block_size(page_id)),
@@ -794,10 +795,10 @@ pub proof fn preserves_mem_chunk_good_on_transfer_back(local1: Local, local2: Lo
     }
 
     assert((pages_range_total1 - pages_range_total2).subset_of(rng));
-    assert((pages_range_total1 - pages_range_total2).subset_of(mem.points_to.dom()));
+    assert((pages_range_total1 - pages_range_total2).subset_of(mem.points_to.dom().to_iset()));
 
     assert(mem.os_rw_bytes().subset_of(
-          mem.points_to.dom()
+          mem.points_to.dom().to_iset()
             + segment_info_range(sid)
             + pages_range_total2
     ));
@@ -860,7 +861,7 @@ pub proof fn preserves_mem_chunk_on_set_used(local1: Local, local2: Local, page_
     }
     assert(pages_range_total1.subset_of(pages_range_total2));
     assert(mem.os_rw_bytes().subset_of(
-          mem.points_to.dom()
+          mem.points_to.dom().to_iset()
             + segment_info_range(sid)
             + pages_range_total2
     ));
@@ -976,7 +977,7 @@ pub proof fn segment_mem_has_reserved_range(local: Local, page_id: PageId, new_c
     }
     assert(range.disjoint(local.segment_pages_range_total(segment_id)));
 
-    assert(range.subset_of(mem.points_to.dom()));
+    assert(range.subset_of(mem.points_to.dom().to_iset()));
 }
 
 ///////

--- a/verus-mimalloc/os_mem_util.rs
+++ b/verus-mimalloc/os_mem_util.rs
@@ -38,7 +38,6 @@ impl MemChunk {
     ) -> (tracked t: Self)
         ensures
             t.points_to.dom().to_iset() == old(self).points_to.dom().to_iset().intersect(set_int_range(start, start + len)),
-t.points_to.dom().to_iset() == old(self).points_to.dom().to_iset().intersect(set_int_range(start, start + len)),
             t.os == old(self).os.restrict(set_int_range(start, start + len)),
             self.points_to.dom() == old(self).points_to.dom().difference(vstd::set_lib::set_int_range(start, start + len)),
             self.os == old(self).os.remove_keys(set_int_range(start, start + len)),

--- a/verus-mimalloc/page.rs
+++ b/verus-mimalloc/page.rs
@@ -286,7 +286,7 @@ fn page_init(heap_ptr: HeapPtr, page_ptr: PagePtr, block_size: usize, tld_ptr: T
         assert(local.page_organization.pages.dom().contains(pid));
         assert(local.page_organization.pages[pid].is_used == false);
     }
-    let ghost new_page_state_map = Map::new(
+    let ghost new_page_state_map = IMap::new(
             |pid: PageId| range.contains(pid),
             |pid: PageId| PageState {
                 offset: pid.idx - page_id.idx,
@@ -383,7 +383,7 @@ fn page_init(heap_ptr: HeapPtr, page_ptr: PagePtr, block_size: usize, tld_ptr: T
 
     proof {
         let tracked new_psa_map = local.unused_pages.tracked_remove_keys(range);
-        let ghost new_page_state_map2 = Map::new(
+        let ghost new_page_state_map2 = IMap::new(
             |pid: PageId| range.contains(pid),
             |pid: PageId| PageState {
                 //offset: pid.idx - page_id.idx,

--- a/verus-mimalloc/page_organization.rs
+++ b/verus-mimalloc/page_organization.rs
@@ -59,8 +59,8 @@ state_machine!{ PageOrg {
         // Roughly corresponds to physical state
         pub unused_dlist_headers: Seq<DlistHeader>,     // indices are sbin
         pub used_dlist_headers: Seq<DlistHeader>,       // indices are bin
-        pub pages: Map<PageId, PageData>,
-        pub segments: Map<SegmentId, SegmentData>,
+        pub pages: IMap<PageId, PageData>,
+        pub segments: IMap<SegmentId, SegmentData>,
 
         // Actor state
         pub popped: Popped,
@@ -972,8 +972,8 @@ state_machine!{ PageOrg {
                 |i| DlistHeader { first: None, last: None });
             init used_dlist_headers = Seq::new((BIN_FULL + 1) as nat,
                 |i| DlistHeader { first: None, last: None });
-            init pages = Map::empty();
-            init segments = Map::empty();
+            init pages = IMap::empty();
+            init segments = IMap::empty();
             init popped = Popped::No;
 
             // TODO internals
@@ -1188,7 +1188,7 @@ state_machine!{ PageOrg {
             require pre.popped == Popped::No;
             require !pre.segments.dom().contains(segment_id);
 
-            let new_pages = Map::new(
+            let new_pages = IMap::new(
                 |page_id: PageId| page_id.segment_id == segment_id
                     && 0 <= page_id.idx <= SLICES_PER_SEGMENT,
                 |page_id: PageId| PageData {
@@ -1225,7 +1225,7 @@ state_machine!{ PageOrg {
                     ==> !pre.pages[pid].is_used
                 );
 
-            let changed_pages = Map::new(
+            let changed_pages = IMap::new(
                 |pid: PageId| pid.segment_id == page_id.segment_id &&
                     page_id.idx <= pid.idx < page_id.idx + count,
                 |pid: PageId| PageData {
@@ -1272,7 +1272,7 @@ state_machine!{ PageOrg {
             let page_id = PageId { segment_id, idx: 0 };
             assert pre.pages.dom().contains(page_id);
             assert count + page_id.idx <= SLICES_PER_SEGMENT;
-            let changed_pages = Map::new(
+            let changed_pages = IMap::new(
                 |pid: PageId| pid.segment_id == segment_id &&
                     0 <= pid.idx < count,
                 |pid: PageId| PageData {
@@ -1430,7 +1430,7 @@ state_machine!{ PageOrg {
                         && pre.pages[pid].offset.unwrap() == pid.idx - page_id.idx
                 );
 
-            let changed_pages = Map::new(
+            let changed_pages = IMap::new(
                 |pid: PageId| pid.segment_id == page_id.segment_id &&
                     page_id.idx <= pid.idx < page_id.idx + count,
                 |pid: PageId| PageData {
@@ -1472,7 +1472,7 @@ state_machine!{ PageOrg {
                         && pre.pages[pid].offset.unwrap() == pid.idx - page_id.idx
                 );
 
-            let changed_pages = Map::new(
+            let changed_pages = IMap::new(
                 |pid: PageId| pid.segment_id == page_id.segment_id &&
                     page_id.idx <= pid.idx < page_id.idx + count,
                 |pid: PageId| PageData {
@@ -1712,7 +1712,7 @@ state_machine!{ PageOrg {
 
             let last_id = PageId { segment_id, idx: (count - 1) as nat };
 
-            let new_page_map = Map::<PageId, PageData>::new(
+            let new_page_map = IMap::<PageId, PageData>::new(
                 |page_id: PageId| page_id.segment_id == segment_id && 0 <= page_id.idx < count,
                 |page_id: PageId| PageData {
                     dlist_entry: None,
@@ -1738,7 +1738,7 @@ state_machine!{ PageOrg {
             update segments = pre.segments.remove(segment_id);
             update popped = Popped::No;
 
-            let keys = Set::<PageId>::new(
+            let keys = ISet::<PageId>::new(
                 |page_id: PageId| page_id.segment_id == segment_id && 0 <= page_id.idx <= SLICES_PER_SEGMENT);
             update pages = pre.pages.remove_keys(keys);
         }
@@ -5070,7 +5070,7 @@ pub open spec fn get_prev(ll: Seq<PageId>, j: int) -> Option<PageId> {
     }
 }
 
-pub open spec fn valid_ll_i(pages: Map<PageId, PageData>, ll: Seq<PageId>, j: int) -> bool {
+pub open spec fn valid_ll_i(pages: IMap<PageId, PageData>, ll: Seq<PageId>, j: int) -> bool {
     0 <= j < ll.len()
       && pages.dom().contains(ll[j])
       && pages[ll[j]].dlist_entry.is_some()
@@ -5078,7 +5078,7 @@ pub open spec fn valid_ll_i(pages: Map<PageId, PageData>, ll: Seq<PageId>, j: in
       && pages[ll[j]].dlist_entry.unwrap().next == get_next(ll, j)
 }
 
-pub open spec fn valid_ll(pages: Map<PageId, PageData>, header: DlistHeader, ll: Seq<PageId>) -> bool {
+pub open spec fn valid_ll(pages: IMap<PageId, PageData>, header: DlistHeader, ll: Seq<PageId>) -> bool {
     &&& (match header.first {
         Some(first_id) => ll.len() != 0 && ll[0] == first_id,
         None => ll.len() == 0,

--- a/verus-mimalloc/pigeonhole.rs
+++ b/verus-mimalloc/pigeonhole.rs
@@ -7,7 +7,7 @@ use vstd::assert_by_contradiction;
 verus!{
 
 // TODO: This belongs in set_lib
-proof fn singleton_set_unique_elt<T>(s: Set<T>, a:T, b:T)
+proof fn singleton_set_unique_elt<T>(s: ISet<T>, a:T, b:T)
     requires
         s.finite(),
         s.len() == 1,
@@ -23,7 +23,7 @@ proof fn singleton_set_unique_elt<T>(s: Set<T>, a:T, b:T)
     });
 }
 
-proof fn set_mismatch(s1:Set<nat>, s2:Set<nat>, missing:nat)
+proof fn set_mismatch(s1:ISet<nat>, s2:ISet<nat>, missing:nat)
     requires
         s1.finite(),
         s2.finite(),
@@ -51,12 +51,12 @@ proof fn set_mismatch(s1:Set<nat>, s2:Set<nat>, missing:nat)
     }
 }
 
-/* TODO: These next two should be derived from the set_int_range and lemma_int_range in 
+/* TODO: These next two should be derived from the ISet::<int>::range and lemma_int_range in 
  *       set_lib.rs, but it's surprisingly painful to do so */
 
 /// Creates a finite set of nats in the range [lo, hi).
-pub open spec fn set_nat_range(lo: nat, hi: nat) -> Set<nat> {
-    Set::new(|i: nat| lo <= i && i < hi)
+pub open spec fn set_nat_range(lo: nat, hi: nat) -> ISet<nat> {
+    ISet::new(|i: nat| lo <= i && i < hi)
 }
 
 /// If a set solely contains nats in the range [a, b), then its size is
@@ -71,7 +71,7 @@ pub proof fn lemma_nat_range(lo: nat, hi: nat)
         hi - lo,
 {
     if lo == hi {
-        assert(set_nat_range(lo, hi) =~= Set::empty());
+        assert(set_nat_range(lo, hi) =~= ISet::empty());
     } else {
         lemma_nat_range(lo, (hi - 1) as nat);
         assert(set_nat_range(lo, (hi - 1) as nat).insert((hi - 1) as nat) =~= set_nat_range(lo, hi));
@@ -79,7 +79,7 @@ pub proof fn lemma_nat_range(lo: nat, hi: nat)
 }
 
 
-proof fn nat_set_size(s:Set<nat>, bound:nat)
+proof fn nat_set_size(s:ISet<nat>, bound:nat)
     requires
         forall |i: nat| (0 <= i < bound <==> s.contains(i)),
     ensures
@@ -94,10 +94,10 @@ proof fn nat_set_size(s:Set<nat>, bound:nat)
         
 
 pub proof fn pigeonhole_missing_idx_implies_double_helper(
-    m: Map<nat, nat>,
+    m: IMap<nat, nat>,
     missing: nat,
     len: nat,
-    prev_vals: Set<nat>,
+    prev_vals: ISet<nat>,
     k: nat,
 ) -> (dup2: nat)
     requires
@@ -144,7 +144,7 @@ pub proof fn pigeonhole_missing_idx_implies_double_helper(
 }
 
 pub proof fn pigeonhole_missing_idx_implies_double(
-    m: Map<nat, nat>,
+    m: IMap<nat, nat>,
     missing: nat,
     len: nat,
 ) -> (r: (nat, nat))
@@ -168,13 +168,13 @@ pub proof fn pigeonhole_missing_idx_implies_double(
             assert(m[0] != missing);
         }
     };
-    let dup2 = pigeonhole_missing_idx_implies_double_helper(m, missing, len, Set::empty(), 0);
+    let dup2 = pigeonhole_missing_idx_implies_double_helper(m, missing, len, ISet::empty(), 0);
     let dup1 = choose |dup1| #![auto] dup1 != dup2 && m.dom().contains(dup1) && 0 <= dup1 < len && m[dup1] == m[dup2];
     (dup1, dup2)
 }
 
 pub proof fn pigeonhole_too_many_elements_implies_double(
-    m: Map<nat, nat>,
+    m: IMap<nat, nat>,
     len: nat,
 ) -> (r: (nat, nat))
     requires

--- a/verus-mimalloc/segment.rs
+++ b/verus-mimalloc/segment.rs
@@ -5,10 +5,9 @@ use core::intrinsics::{unlikely, likely};
 use vstd::prelude::*;
 use vstd::raw_ptr::*;
 use vstd::*;
+use vstd::iset_lib::*;
 use vstd::modes::*;
-use vstd::set_lib::*;
 use vstd::pervasive::*;
-use vstd::set_lib::*;
 use vstd::cell::pcell::*;
 use vstd::atomic_ghost::*;
 
@@ -770,7 +769,7 @@ fn segment_span_allocate(
         //assert(inner.xblock_size != 0);
     });
 
-    // Set up the remaining pages
+    // ISet up the remaining pages
     let mut i: usize = 1;
     let ghost local_snapshot = *local;
     let extra = slice_count - 1;
@@ -822,7 +821,7 @@ fn segment_span_allocate(
         ptr_mut_write(this_slice.page_ptr, Tracked(&mut this_psa.points_to), page);
         proof {
             local.unused_pages.tracked_insert(this_page_id, this_psa);
-            assert_sets_equal!(local.unused_pages.dom() == prelocal.unused_pages.dom());
+            assert_isets_equal!(local.unused_pages.dom() == prelocal.unused_pages.dom());
         }
 
         i = i + 1;
@@ -1050,8 +1049,8 @@ fn segment_alloc(
     ) as *mut Page;
     //assert(i * SIZEOF_PAGE_HEADER == 0);
     let ghost old_mem_chunk = mem_chunk;
-    let tracked mut psa_map = Map::<PageId, PageSharedAccess>::tracked_empty();
-    let tracked mut pla_map = Map::<PageId, PageLocalAccess>::tracked_empty();
+    let tracked mut psa_map = IMap::<PageId, PageSharedAccess>::tracked_empty();
+    let tracked mut pla_map = IMap::<PageId, PageLocalAccess>::tracked_empty();
     //assert(segment_ptr.segment_ptr@.provenance == segment_ptr.segment_id@.provenance);
     while i <= SLICES_PER_SEGMENT as usize
         invariant mem_chunk.os == old_mem_chunk.os,
@@ -1060,8 +1059,8 @@ fn segment_alloc(
             //  COMMIT_SIZE - (SIZEOF_SEGMENT_HEADER + i * SIZEOF_PAGE_HEADER)),
             set_int_range(
                     segment_start(segment_id) + SIZEOF_SEGMENT_HEADER,
-                    segment_start(segment_id) + COMMIT_SIZE) <= old_mem_chunk.points_to.dom(),
-            mem_chunk.points_to.dom() =~= old_mem_chunk.points_to.dom() - 
+                    segment_start(segment_id) + COMMIT_SIZE) <= old_mem_chunk.points_to.dom().to_iset(),
+            mem_chunk.points_to.dom().to_iset() =~= old_mem_chunk.points_to.dom().to_iset() - 
                 set_int_range(
                     segment_start(segment_id),
                     segment_start(segment_id) + SIZEOF_SEGMENT_HEADER + i * SIZEOF_PAGE_HEADER
@@ -1221,7 +1220,7 @@ fn segment_alloc(
                 ssa);
         local.thread_token = thread_state_tok;
 
-        ////////// Set up pages and stuff
+        ////////// ISet up pages and stuff
 
         local.page_organization = PageOrg::take_step::create_segment(local.page_organization, segment_id);
 
@@ -1366,7 +1365,7 @@ fn segment_os_alloc(
             &&& set_int_range(segment_start(segment_ptr.segment_id@),
                     segment_start(segment_ptr.segment_id@) + COMMIT_SIZE).subset_of( pcommit_mask.bytes(segment_ptr.segment_id@) )
             &&& pcommit_mask.bytes(segment_ptr.segment_id@).subset_of(mem_chunk@.os_rw_bytes())
-            &&& mem_chunk@.os_rw_bytes().subset_of(mem_chunk@.points_to.dom())
+            &&& mem_chunk@.os_rw_bytes().subset_of(mem_chunk@.points_to.dom().to_iset())
         })
         }
     })
@@ -1467,7 +1466,7 @@ fn segment_os_alloc(
         by {
             reveal(CommitMask::bytes);
         }
-        assert(mem.os_rw_bytes().subset_of(mem.points_to.dom()));
+        assert(mem.os_rw_bytes().subset_of(mem.points_to.dom().to_iset()));
     }
 
     return (segment, psegment_slices, pre_size, pinfo_slices, is_zero, pcommit, mem_id, mem_large, is_pinned, align_offset, Tracked(mem));
@@ -1698,7 +1697,7 @@ fn segment_span_free(
         local.page_organization = next_state;
         local.psa = local.psa.union_prefer_right(local.unused_pages);
 
-        assert_sets_equal!(local.page_organization.pages.dom(), local.pages.dom());
+        assert_isets_equal!(local.page_organization.pages.dom(), local.pages.dom());
         preserves_mem_chunk_good(local_snap, *local);
 
         /*
@@ -1818,7 +1817,7 @@ fn segment_page_clear(page: PagePtr, tld: TldPtr, Tracked(local): Tracked<&mut L
     let tracked psa_map;
     proof {
         let tracked thread_state_tok = local.take_thread_token();
-        let block_state_map = Map::new(
+        let block_state_map = IMap::new(
             |block_id: BlockId| block_tokens.dom().contains(block_id),
             |block_id: BlockId| block_tokens[block_id].value(),
         );

--- a/verus-mimalloc/tokens.rs
+++ b/verus-mimalloc/tokens.rs
@@ -53,8 +53,8 @@ pub ghost struct BlockId {
 }
 
 impl PageId {
-    pub open spec fn range_from(&self, lo: int, hi: int) -> Set<PageId> {
-        Set::new(
+    pub open spec fn range_from(&self, lo: int, hi: int) -> ISet<PageId> {
+        ISet::new(
             |page_id: PageId| page_id.segment_id == self.segment_id
               && self.idx + lo <= page_id.idx < self.idx + hi
         )
@@ -147,7 +147,7 @@ pub ghost struct PageQueueIds {
 
 pub ghost struct HeapState {
     // For the doubly-linked list of Pages
-    //pub pages: Map<int, PageQueueIds>,
+    //pub pages: IMap<int, PageQueueIds>,
     //pub full_list: PageQueueIds,
 
     pub shared_access: HeapSharedAccess,
@@ -157,12 +157,12 @@ pub ghost struct ThreadState {
     pub heap_id: HeapId,
     pub heap: HeapState,
 
-    pub segments: Map<SegmentId, SegmentState>,
-    pub pages: Map<PageId, PageState>,
+    pub segments: IMap<SegmentId, SegmentState>,
+    pub pages: IMap<PageId, PageState>,
 }
 
 pub ghost struct ThreadCheckedState {
-    pub pages: Set<PageId>,
+    pub pages: ISet<PageId>,
 }
 
 
@@ -204,7 +204,7 @@ pub type ThreadId = crate::thread::ThreadId;
 
 // PAPER CUT: doing this more than once, no generic finite condition for map,
 // having to do the maximum thing
-pub open spec fn segment_u_max(s: Set<SegmentId>) -> int
+pub open spec fn segment_u_max(s: ISet<SegmentId>) -> int
     decreases s.len() when s.finite()
 {
     if s.len() == 0 {
@@ -215,14 +215,14 @@ pub open spec fn segment_u_max(s: Set<SegmentId>) -> int
     }
 }
 
-proof fn segment_u_max_not_in(s: Set<SegmentId>)
+proof fn segment_u_max_not_in(s: ISet<SegmentId>)
     requires s.finite(),
     ensures forall |id: SegmentId| s.contains(id) ==> id.uniq < segment_u_max(s) + 1,
     decreases s.len(),
 {
-    vstd::set_lib::lemma_set_empty_equivalency_len(s);
+    vstd::iset_lib::lemma_iset_empty_equivalency_len(s);
     if s.len() == 0 {
-        assert(s === Set::empty());
+        assert(s === ISet::empty());
     } else {
         let x = s.choose();
         let t = s.remove(x);
@@ -230,18 +230,18 @@ proof fn segment_u_max_not_in(s: Set<SegmentId>)
     }
 }
 
-pub open spec fn segment_get_unused_uniq_field(s: Set<SegmentId>) -> int {
+pub open spec fn segment_get_unused_uniq_field(s: ISet<SegmentId>) -> int {
     segment_u_max(s) + 1
 }
 
-pub proof fn lemma_segment_get_unused_uniq_field(s: Set<SegmentId>)
+pub proof fn lemma_segment_get_unused_uniq_field(s: ISet<SegmentId>)
     requires s.finite(),
     ensures forall |id: SegmentId| s.contains(id) ==> id.uniq != segment_get_unused_uniq_field(s)
 {
     segment_u_max_not_in(s);
 }
 
-pub open spec fn heap_u_max(s: Set<HeapId>) -> int
+pub open spec fn heap_u_max(s: ISet<HeapId>) -> int
     decreases s.len() when s.finite()
 {
     if s.len() == 0 {
@@ -252,14 +252,14 @@ pub open spec fn heap_u_max(s: Set<HeapId>) -> int
     }
 }
 
-proof fn heap_u_max_not_in(s: Set<HeapId>)
+proof fn heap_u_max_not_in(s: ISet<HeapId>)
     requires s.finite(),
     ensures forall |id: HeapId| s.contains(id) ==> id.uniq < heap_u_max(s) + 1,
     decreases s.len(),
 {
-    vstd::set_lib::lemma_set_empty_equivalency_len(s);
+    vstd::iset_lib::lemma_iset_empty_equivalency_len(s);
     if s.len() == 0 {
-        assert(s === Set::empty());
+        assert(s === ISet::empty());
     } else {
         let x = s.choose();
         let t = s.remove(x);
@@ -267,11 +267,11 @@ proof fn heap_u_max_not_in(s: Set<HeapId>)
     }
 }
 
-pub open spec fn heap_get_unused_uniq_field(s: Set<HeapId>) -> int {
+pub open spec fn heap_get_unused_uniq_field(s: ISet<HeapId>) -> int {
     heap_u_max(s) + 1
 }
 
-pub proof fn lemma_heap_get_unused_uniq_field(s: Set<HeapId>)
+pub proof fn lemma_heap_get_unused_uniq_field(s: ISet<HeapId>)
     requires s.finite(),
     ensures forall |id: HeapId| s.contains(id) ==> id.uniq != heap_get_unused_uniq_field(s)
 {
@@ -290,70 +290,70 @@ tokenized_state_machine!{ Mim {
         #[sharding(persistent_option)] pub my_inst: Option<InstanceId>,
 
         /*
-        #[sharding(map)] pub heap: Map<HeapId, HeapState>,
-        #[sharding(map)] pub tld: Map<ThreadId, ThreadState>,
-        #[sharding(map)] pub segment: Map<SegmentId, SegmentState>,
-        #[sharding(map)] pub page: Map<PageId, PageState>,
+        #[sharding(imap)] pub heap: IMap<HeapId, HeapState>,
+        #[sharding(imap)] pub tld: IMap<ThreadId, ThreadState>,
+        #[sharding(imap)] pub segment: IMap<SegmentId, SegmentState>,
+        #[sharding(imap)] pub page: IMap<PageId, PageState>,
         */
-        #[sharding(map)] pub thread_local_state: Map<ThreadId, ThreadState>,
-        #[sharding(set)] pub right_to_use_thread: Set<ThreadId>,
+        #[sharding(imap)] pub thread_local_state: IMap<ThreadId, ThreadState>,
+        #[sharding(iset)] pub right_to_use_thread: ISet<ThreadId>,
 
         // Blocks that are allocated (these ghost shards are handed to the user
         // to give them the right to 'deallocate')
 
-        #[sharding(map)] pub block: Map<BlockId, BlockState>,
+        #[sharding(imap)] pub block: IMap<BlockId, BlockState>,
 
         // Atomics (accessed concurrently)
 
-        #[sharding(map)] pub thread_of_segment: Map<SegmentId, ThreadId>,
-        #[sharding(map)] pub delay: Map<PageId, DelayState>,
-        #[sharding(map)] pub heap_of_page: Map<PageId, HeapId>,
+        #[sharding(imap)] pub thread_of_segment: IMap<SegmentId, ThreadId>,
+        #[sharding(imap)] pub delay: IMap<PageId, DelayState>,
+        #[sharding(imap)] pub heap_of_page: IMap<PageId, HeapId>,
 
         // Thread actors
 
-        #[sharding(map)] pub actor: Map<ThreadId, Actor>,
-        #[sharding(map)] pub delay_actor: Map<PageId, DelayFreeingActor>,
+        #[sharding(imap)] pub actor: IMap<ThreadId, Actor>,
+        #[sharding(imap)] pub delay_actor: IMap<PageId, DelayFreeingActor>,
 
         // Storage
 
-        #[sharding(storage_map)] pub segment_shared_access: Map<SegmentId, SegmentSharedAccess>,
+        #[sharding(storage_imap)] pub segment_shared_access: IMap<SegmentId, SegmentSharedAccess>,
 
-        #[sharding(storage_map)] pub page_shared_access: Map<PageId, PageSharedAccess>,
+        #[sharding(storage_imap)] pub page_shared_access: IMap<PageId, PageSharedAccess>,
 
-        #[sharding(storage_map)] pub heap_shared_access: Map<HeapId, HeapSharedAccess>,
+        #[sharding(storage_imap)] pub heap_shared_access: IMap<HeapId, HeapSharedAccess>,
 
         // PAPER CUT
         // reason - deposit can't be after birds_eye so create_thread_mk_tokens needs to work
         // in two steps
-        #[sharding(set)] pub reserved_uniq: Set<HeapId>,
+        #[sharding(iset)] pub reserved_uniq: ISet<HeapId>,
 
-        #[sharding(map)] pub thread_checked_state: Map<ThreadId, ThreadCheckedState>,
+        #[sharding(imap)] pub thread_checked_state: IMap<ThreadId, ThreadCheckedState>,
 
         // Extra state that doesn't form tokens but helps writing invariants
 
-        //#[sharding(not_tokenized)] pub thread_segments: Map<ThreadId, Seq<SegmentId>>,
+        //#[sharding(not_tokenized)] pub thread_segments: IMap<ThreadId, Seq<SegmentId>>,
 
-        #[sharding(not_tokenized)] pub heap_to_thread: Map<HeapId, ThreadId>,
+        #[sharding(not_tokenized)] pub heap_to_thread: IMap<HeapId, ThreadId>,
     }
 
     init!{
         initialize() {
             init right_to_set_inst = true;
             init my_inst = Option::None;
-            init right_to_use_thread = Set::full();
-            init thread_local_state = Map::empty();
-            init thread_checked_state = Map::empty();
-            init block = Map::empty();
-            init thread_of_segment = Map::empty();
-            init delay = Map::empty();
-            init heap_of_page = Map::empty();
-            init actor = Map::empty();
-            init delay_actor = Map::empty();
-            init segment_shared_access = Map::empty();
-            init page_shared_access = Map::empty();
-            init heap_shared_access = Map::empty();
-            init heap_to_thread = Map::empty();
-            init reserved_uniq = Set::empty();
+            init right_to_use_thread = ISet::full();
+            init thread_local_state = IMap::empty();
+            init thread_checked_state = IMap::empty();
+            init block = IMap::empty();
+            init thread_of_segment = IMap::empty();
+            init delay = IMap::empty();
+            init heap_of_page = IMap::empty();
+            init actor = IMap::empty();
+            init delay_actor = IMap::empty();
+            init segment_shared_access = IMap::empty();
+            init page_shared_access = IMap::empty();
+            init heap_shared_access = IMap::empty();
+            init heap_to_thread = IMap::empty();
+            init reserved_uniq = ISet::empty();
         }
     }
 
@@ -610,7 +610,7 @@ tokenized_state_machine!{ Mim {
     // Setting up a page
 
     /*pub open spec fn block_map_on_create_page(page_id: PageId, n_blocks: nat, block_size: nat)
-        Map::new(
+        IMap::new(
             |block_id: BlockId|
                 block_id.page_id == page_id
                   && 0 <= block_id.idx < n_blocks
@@ -649,8 +649,8 @@ tokenized_state_machine!{ Mim {
         ) {
             remove right_to_use_thread -= set { thread_id };
             remove reserved_uniq -= set { HeapId { id: 0, uniq: thread_state.heap_id.uniq, provenance: Provenance::null() } };
-            require thread_state.pages.dom() =~= Set::empty();
-            require thread_state.segments.dom() =~= Set::empty();
+            require thread_state.pages.dom() =~= ISet::empty();
+            require thread_state.segments.dom() =~= ISet::empty();
             have my_inst >= Some(let inst);
 
             require thread_state.heap.shared_access.wf2(thread_state.heap_id, inst);
@@ -671,11 +671,11 @@ tokenized_state_machine!{ Mim {
             };
 
             add thread_local_state += [ thread_id => real_thread_state ];
-            add thread_checked_state += [ thread_id => ThreadCheckedState { pages: Set::empty() } ];
+            add thread_checked_state += [ thread_id => ThreadCheckedState { pages: ISet::empty() } ];
         }
     }
 
-    pub closed spec fn mk_fresh_segment_id(tos: Map<SegmentId, ThreadId>, sid: SegmentId) -> SegmentId {
+    pub closed spec fn mk_fresh_segment_id(tos: IMap<SegmentId, ThreadId>, sid: SegmentId) -> SegmentId {
         let uniq = segment_get_unused_uniq_field(tos.dom());
         SegmentId { id: sid.id, provenance: sid.provenance, uniq: uniq }
     }
@@ -727,16 +727,16 @@ tokenized_state_machine!{ Mim {
             page_id: PageId,
             n_slices: nat,
             block_size: nat,
-            page_map: Map<PageId, PageState>,
+            page_map: IMap<PageId, PageState>,
         ) {
             remove thread_local_state -= [ thread_id => let ts ];
 
             require ts.segments.dom().contains(page_id.segment_id);
             require ts.segments[page_id.segment_id].is_enabled;
 
-            //let range = Set::new(|pid: PageId| pid.segment_id == page_id.segment_id
+            //let range = ISet::new(|pid: PageId| pid.segment_id == page_id.segment_id
             //      && page_id.idx <= pid.idx < page_id.idx + n_slices);
-            //let new_pages = Map::new(
+            //let new_pages = IMap::new(
             //    |pid: PageId| range.contains(pid),
             //    |pid: PageId| 
             //);
@@ -762,7 +762,7 @@ tokenized_state_machine!{ Mim {
 
             /*birds_eye let ssa = pre.segment_shared_access[page_id.segment_id];
 
-            let block_map = Map::new(
+            let block_map = IMap::new(
                 |block_id: BlockId|
                     block_id.page_id == page_id
                       && 0 <= block_id.idx < n_blocks
@@ -788,8 +788,8 @@ tokenized_state_machine!{ Mim {
             thread_id: ThreadId,
             page_id: PageId,
             n_slices: nat,
-            page_map: Map<PageId, PageState>,
-            psa_map: Map<PageId, PageSharedAccess>
+            page_map: IMap<PageId, PageState>,
+            psa_map: IMap<PageId, PageSharedAccess>
         ) {
             remove thread_local_state -= [ thread_id => let ts ];
 
@@ -862,7 +862,7 @@ tokenized_state_machine!{ Mim {
 
             birds_eye let ssa = pre.segment_shared_access[page_id.segment_id];
             //let ssa = ts.segments[page_id.segment_id].shared_access;
-            let block_map = Map::new(
+            let block_map = IMap::new(
                 |block_id: BlockId|
                     block_id.page_id == page_id
                       && old_num_blocks <= block_id.idx < new_num_blocks
@@ -900,7 +900,7 @@ tokenized_state_machine!{ Mim {
         page_destroy_block_tokens(
             thread_id: ThreadId,
             page_id: PageId,
-            blocks: Map<BlockId, BlockState>,
+            blocks: IMap<BlockId, BlockState>,
         ) {
             remove thread_local_state -= [ thread_id => let ts ];
             require ts.pages.dom().contains(page_id);
@@ -965,7 +965,7 @@ tokenized_state_machine!{ Mim {
             //          && ts.pages.dom().contains(pid)
             //          ==> ts.pages[pid].offset != pid.idx - page_id.idx;
 
-            let new_pages0 = Map::<PageId, PageState>::new(
+            let new_pages0 = IMap::<PageId, PageState>::new(
                 |pid: PageId| page_id.range_from(0, n_slices as int).contains(pid),
                 |pid: PageId|
                     PageState {
@@ -978,7 +978,7 @@ tokenized_state_machine!{ Mim {
             let ts2 = ThreadState { pages: new_pages, .. ts };
             add thread_local_state += [ thread_id => ts2 ];
 
-            let psa_map = Map::new(
+            let psa_map = IMap::new(
                 |pid: PageId| page_id.range_from(0, n_slices as int).contains(pid),
                 |pid: PageId| ts.pages[pid].shared_access,
             );
@@ -1214,7 +1214,7 @@ tokenized_state_machine!{ Mim {
     #[invariant]
     pub closed spec fn wf_heap_shared_access_requires_inst(&self) -> bool {
         self.my_inst.is_none() ==> 
-            self.heap_shared_access.dom() =~= Set::empty()
+            self.heap_shared_access.dom() =~= ISet::empty()
     }
 
     #[invariant]
@@ -1453,12 +1453,12 @@ tokenized_state_machine!{ Mim {
     fn segment_enable_inductive(pre: Self, post: Self, thread_id: ThreadId, segment_id: SegmentId, shared_access: SegmentSharedAccess) { }
    
     #[inductive(create_page_mk_tokens)]
-    fn create_page_mk_tokens_inductive(pre: Self, post: Self, thread_id: ThreadId, page_id: PageId, n_slices: nat, block_size: nat, page_map: Map<PageId, PageState>) {
+    fn create_page_mk_tokens_inductive(pre: Self, post: Self, thread_id: ThreadId, page_id: PageId, n_slices: nat, block_size: nat, page_map: IMap<PageId, PageState>) {
         
     }
    
     #[inductive(page_enable)]
-    fn page_enable_inductive(pre: Self, post: Self, thread_id: ThreadId, page_id: PageId, n_slices: nat, page_map: Map<PageId, PageState>, psa_map: Map<PageId, PageSharedAccess>) { }
+    fn page_enable_inductive(pre: Self, post: Self, thread_id: ThreadId, page_id: PageId, n_slices: nat, page_map: IMap<PageId, PageState>, psa_map: IMap<PageId, PageSharedAccess>) { }
    
     #[inductive(page_mk_block_tokens)]
     fn page_mk_block_tokens_inductive(pre: Self, post: Self, thread_id: ThreadId, page_id: PageId, old_num_blocks: nat, new_num_blocks: nat, block_size: nat) {
@@ -1477,7 +1477,7 @@ tokenized_state_machine!{ Mim {
         }
     }
 
-    proof fn block_map_with_len(blocks: Map<BlockId, BlockState>, page_id: PageId, len: int)
+    proof fn block_map_with_len(blocks: IMap<BlockId, BlockState>, page_id: PageId, len: int)
         requires
             blocks.dom().finite(), blocks.len() >= len,
             len >= 0,
@@ -1494,7 +1494,7 @@ tokenized_state_machine!{ Mim {
     {
         if len == 0 {
             if (blocks.len() > len) {
-                vstd::set_lib::lemma_set_empty_equivalency_len(blocks.dom());
+                vstd::iset_lib::lemma_iset_empty_equivalency_len(blocks.dom());
                 let t = choose |t: BlockId| blocks.dom().contains(t);
                 assert(blocks.dom().contains(t));
                 assert(false);
@@ -1522,13 +1522,13 @@ tokenized_state_machine!{ Mim {
         }
     }
 
-    spec fn blocks_has(blocks: Map<BlockId, BlockState>, page_id: PageId, i: int) -> bool {
+    spec fn blocks_has(blocks: IMap<BlockId, BlockState>, page_id: PageId, i: int) -> bool {
         exists |block_id| blocks.dom().contains(block_id) && block_id.page_id == page_id
             && block_id.idx == i
     }
 
     #[inductive(page_destroy_block_tokens)]
-    fn page_destroy_block_tokens_inductive(pre: Self, post: Self, thread_id: ThreadId, page_id: PageId, blocks: Map<BlockId, BlockState>) {
+    fn page_destroy_block_tokens_inductive(pre: Self, post: Self, thread_id: ThreadId, page_id: PageId, blocks: IMap<BlockId, BlockState>) {
         let ts = pre.thread_local_state[thread_id];
         assert(forall |block_id: BlockId| blocks.dom().contains(block_id) ==>
             pre.block.dom().contains(block_id));
@@ -1632,7 +1632,7 @@ tokenized_state_machine!{ Mim {
             ts.pages[page_id].num_blocks == 0,
             page_id.range_from(0, n_slices as int).subset_of(ts.pages.dom()),
       ensures ({
-            let psa_map = Map::new(
+            let psa_map = IMap::new(
                 |pid: PageId| page_id.range_from(0, n_slices as int).contains(pid),
                 |pid: PageId| ts.pages[pid].shared_access,
             );

--- a/verus-mimalloc/types.rs
+++ b/verus-mimalloc/types.rs
@@ -635,15 +635,15 @@ pub tracked struct Local {
     pub ghost tld_id: TldId,
     pub tracked tld: raw_ptr::PointsTo<Tld>,
 
-    pub tracked segments: Map<SegmentId, SegmentLocalAccess>,
+    pub tracked segments: IMap<SegmentId, SegmentLocalAccess>,
 
     // All pages, used and unused
-    pub tracked pages: Map<PageId, PageLocalAccess>,
-    pub ghost psa: Map<PageId, PageSharedAccess>,
+    pub tracked pages: IMap<PageId, PageLocalAccess>,
+    pub ghost psa: IMap<PageId, PageSharedAccess>,
 
     // All unused pages
     // (used pages are in the token system)
-    pub tracked unused_pages: Map<PageId, PageSharedAccess>,
+    pub tracked unused_pages: IMap<PageId, PageSharedAccess>,
 
     pub ghost page_organization: PageOrg::State,
 
@@ -883,9 +883,9 @@ pub open spec fn page_organization_used_queues_match(
 
 
 pub open spec fn page_organization_pages_match(
-    org_pages: Map<PageId, PageData>,
-    pages: Map<PageId, PageLocalAccess>,
-    psa: Map<PageId, PageSharedAccess>,
+    org_pages: IMap<PageId, PageData>,
+    pages: IMap<PageId, PageLocalAccess>,
+    psa: IMap<PageId, PageSharedAccess>,
     popped: Popped,
 ) -> bool {
     &&& org_pages.dom() =~= pages.dom()
@@ -963,8 +963,8 @@ pub open spec fn page_organization_pages_match_data(
 }
 
 pub open spec fn page_organization_segments_match(
-    org_segments: Map<SegmentId, SegmentData>,
-    segments: Map<SegmentId, SegmentLocalAccess>,
+    org_segments: IMap<SegmentId, SegmentData>,
+    segments: IMap<SegmentId, SegmentLocalAccess>,
 ) -> bool {
     org_segments.dom() =~= segments.dom()
     && (forall |segment_id: SegmentId| segments.dom().contains(segment_id) ==>


### PR DESCRIPTION
Verus will be adding finite sets and maps, in https://github.com/verus-lang/verus/pull/2486. This PR is to prepare for that future.

This PR is an alternative to a different PR (https://github.com/verus-lang/verified-memory-allocator/pull/6). That PR chooses some sets to become finite; this PR prefers to just continue using ISet.